### PR TITLE
feat: optionally pass native instance to constructor

### DIFF
--- a/packages/canvas/ImageAsset/ImageAsset.android.ts
+++ b/packages/canvas/ImageAsset/ImageAsset.android.ts
@@ -2,8 +2,8 @@ import { ImageAssetBase, ImageAssetSaveFormat } from './common';
 import { knownFolders, path as filePath } from '@nativescript/core';
 
 export class ImageAsset extends ImageAssetBase {
-    constructor() {
-        super(new org.nativescript.canvas.TNSImageAsset());
+    constructor(native?: org.nativescript.canvas.TNSImageAsset) {
+        super(native || new org.nativescript.canvas.TNSImageAsset());
     }
 
     get width() {

--- a/packages/canvas/ImageAsset/ImageAsset.d.ts
+++ b/packages/canvas/ImageAsset/ImageAsset.d.ts
@@ -5,7 +5,7 @@ export declare class ImageAsset extends ImageAssetBase {
 	height: number;
 	error: string;
 
-	constructor();
+	constructor(native?: any);
 
 	loadFromUrl(url: string): boolean;
 

--- a/packages/canvas/ImageAsset/ImageAsset.ios.ts
+++ b/packages/canvas/ImageAsset/ImageAsset.ios.ts
@@ -7,9 +7,10 @@ const main_queue = dispatch_get_current_queue();
 const background_queue = dispatch_get_global_queue(21, 0);
 
 export class ImageAsset extends ImageAssetBase {
+	//@ts-ignore
 	native: TNSImageAsset
-	constructor() {
-		super(TNSImageAsset.alloc().init());
+    constructor(native?: TNSImageAsset) {
+		super(native || TNSImageAsset.alloc().init());
 	}
 
 	get width() {


### PR DESCRIPTION
I create the native instance on the native side in another thread. Having that constructor allows me to "wrap" my native instance and pass it to Three.js