### PR TITLE
feat: working gestures

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@nativescript/core": "~7.0.0",
 		"@nativescript/types": "~7.0.0",
 		"@nativescript/webpack": "~3.0.0",
+		"@nativescript-community/gesturehandler":"0.1.42",
 		"@ngtools/webpack": "~10.1.0",
 		"@nrwl/eslint-plugin-nx": "~10.1.0",
 		"@nrwl/jest": "~10.1.0",

--- a/packages/canvas-polyfill/index.ts
+++ b/packages/canvas-polyfill/index.ts
@@ -99,3 +99,21 @@ if (!((global as any).URL instanceof URL)) {
 	});
 	(global as any).window.URL = (global as any).URL;
 }
+
+
+class TouchEvent {
+ 
+    preventDefault () {
+    }
+    stopPropagation () {
+    }
+}
+
+if (!((global as any).TouchEvent instanceof TouchEvent)) {
+	Object.defineProperty(global, 'TouchEvent', {
+		value: TouchEvent,
+		configurable: true,
+		writable: true,
+	});
+	(global as any).window.TouchEvent = (global as any).TouchEvent;
+}

--- a/packages/canvas/Canvas/common.ts
+++ b/packages/canvas/Canvas/common.ts
@@ -146,7 +146,7 @@ export abstract class CanvasBase extends View implements ICanvasBase {
 					break;
 			}
 		} else if (event.eventName === 'pinch') {
-			if (event.getPointerCount() >= 2 && event.state === GestureStateTypes.began) {
+			if (!this._isPinching && event.getPointerCount() >= 2 && (event.state === GestureStateTypes.began || event.state === GestureStateTypes.changed)) {
 				this._previousPinchDistance = 0;
 				this._isPinching = true;
 			}

--- a/packages/canvas/Canvas/common.ts
+++ b/packages/canvas/Canvas/common.ts
@@ -129,8 +129,11 @@ export abstract class CanvasBase extends View implements ICanvasBase {
 					}
 					break;
 				case 'up':
-					this._emitEvent('touchend', event);
-					this.__touchStart = undefined;
+					if (event.getPointerCount() === 1 && this.__touchStart) {
+						this._emitEvent('touchend', event);
+						this._isPinching = false;
+						this.__touchStart = undefined;
+					}
 					break;
 				case 'cancel':
 					this._emitEvent('touchcancel', event);

--- a/packages/canvas/Canvas/index.android.ts
+++ b/packages/canvas/Canvas/index.android.ts
@@ -103,7 +103,6 @@ export class Canvas extends CanvasBase {
 	initNativeView(): void {
 		super.initNativeView();
 		const ref = new WeakRef(this);
-		this.__handleGestures();
 		this.on(View.layoutChangedEvent, (args) => {
 			const parent = this.parent as any;
 			// TODO change DIPs once implemented
@@ -162,7 +161,6 @@ export class Canvas extends CanvasBase {
 	}
 
 	disposeNativeView(): void {
-		this.off('touch, pan', this._touchEvents);
 		this._canvas.setListener(null);
 		this._canvas = undefined;
 		this.setNativeView(undefined);

--- a/packages/canvas/Canvas/index.ios.ts
+++ b/packages/canvas/Canvas/index.ios.ts
@@ -139,7 +139,6 @@ export class Canvas extends CanvasBase {
 
 	initNativeView() {
 		super.initNativeView();
-		this.__handleGestures();
 	}
 
 	flush() {
@@ -164,7 +163,6 @@ export class Canvas extends CanvasBase {
 	}
 
 	disposeNativeView(): void {
-		this.off('touch, pan', this._touchEvents);
 		this._canvas.setListener(null);
 		this._readyListener = undefined;
 		this._canvas = undefined;

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -31,5 +31,8 @@
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/NativeScript/canvas",
 	"readmeFilename": "README.md",
-	"bootstrapper": "@nativescript/plugin-seed"
+	"bootstrapper": "@nativescript/plugin-seed",
+	"peerDependencies": {
+		"@nativescript-community/gesturehandler":"0.1.42"
+	}
 }


### PR DESCRIPTION
This add most touch gestures for canvas.
touch:pinch is now emitting wheel event as it seems to be happening in browser on mobile devices

In a sense it is a work in progress there might still be some corner cases, but for the most part it seems to be working.

One thing is not "figured out" yet. `@nativescript-community/gesturehander` requires an install method to be called for gestures to work correctly. Maybe we could do that in the `require('@nativescript/canvas-polyfill');` ?
It needs to be done before the page is created.