### PR TITLE
fix: Avoid `undefined` errors during `instanceof` checks.

### DIFF
--- a/packages/canvas/Canvas2D/DOMMatrix/common.ts
+++ b/packages/canvas/Canvas2D/DOMMatrix/common.ts
@@ -34,6 +34,6 @@ export abstract class DOMMatrixBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'DOMMatrix') return true;
+		if (obj?.native && obj.constructor.name === 'DOMMatrix') return true;
 	}
 }

--- a/packages/canvas/Canvas2D/ImageData/common.ts
+++ b/packages/canvas/Canvas2D/ImageData/common.ts
@@ -13,6 +13,6 @@ export abstract class ImageDataBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'ImageData') return true;
+		if (obj?.native && obj.constructor.name === 'ImageData') return true;
 	}
 }

--- a/packages/canvas/Canvas2D/Path2D/common.ts
+++ b/packages/canvas/Canvas2D/Path2D/common.ts
@@ -12,7 +12,7 @@ export abstract class Path2DBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'Path2D') return true;
+		if (obj?.native && obj.constructor.name === 'Path2D') return true;
 	}
 
 	public abstract addPath(

--- a/packages/canvas/Canvas2D/TextMetrics/common.ts
+++ b/packages/canvas/Canvas2D/TextMetrics/common.ts
@@ -10,7 +10,7 @@ export abstract class TextMetricsBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'TextMetrics') return true;
+		if (obj?.native && obj.constructor.name === 'TextMetrics') return true;
 	}
 
 	public abstract readonly width: number;

--- a/packages/canvas/ImageAsset/common.ts
+++ b/packages/canvas/ImageAsset/common.ts
@@ -10,7 +10,7 @@ export class ImageAssetBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'ImageAsset') return true;
+		if (obj?.native && obj.constructor.name === 'ImageAsset') return true;
 	}
 
 }

--- a/packages/canvas/ImageBitmap/common.ts
+++ b/packages/canvas/ImageBitmap/common.ts
@@ -10,7 +10,7 @@ export abstract class ImageBitmapBase {
 	}
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'ImageBitmap') return true;
+		if (obj?.native && obj.constructor.name === 'ImageBitmap') return true;
 	}
 
 	abstract readonly width: number;

--- a/packages/canvas/TextDecoder/common.ts
+++ b/packages/canvas/TextDecoder/common.ts
@@ -13,7 +13,7 @@ export abstract class TextDecoderBase {
 	abstract decode(buffer: ArrayBuffer | ArrayBufferView, options?: any): string;
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'TextDecoder') return true;
+		if (obj?.native && obj.constructor.name === 'TextDecoder') return true;
 	}
 
 }

--- a/packages/canvas/TextEncoder/common.ts
+++ b/packages/canvas/TextEncoder/common.ts
@@ -13,6 +13,6 @@ export abstract class TextEncoderBase {
 	abstract encode(text: string): Uint8Array;
 
 	static [Symbol.hasInstance](obj) {
-		if (obj.native && obj.constructor.name === 'TextEncoder') return true;
+		if (obj?.native && obj.constructor.name === 'TextEncoder') return true;
 	}
 }


### PR DESCRIPTION
There were cases that `instanceof` threw error because instance was undefined.
Checking if instance is defined solves issues.