### PR TITLE
fix(android): There were invalidate conflicts due to asynchronous executions

### DIFF
--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/CPUView.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/CPUView.kt
@@ -71,7 +71,7 @@ class CPUView @JvmOverloads constructor(
 						canvas.queueEvent {
 							TNSCanvas.nativeCustomWithBitmapFlush(canvas.nativeContext, it)
 							handler!!.post {
-								canvas.pendingInvalidate = false
+								canvas.invalidateState = TNSCanvas.InvalidateState.NONE
 								invalidate()
 							}
 						}

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
@@ -149,19 +149,19 @@ internal class GLContext {
 		queueEvent {
 			if (reference != null) {
 				val canvasView = reference!!.get()
-				if (canvasView != null && canvasView.nativeContext != 0L && canvasView.pendingInvalidate) {
+				if (canvasView != null && canvasView.nativeContext != 0L && canvasView.invalidateState == TNSCanvas.InvalidateState.INVALIDATING) {
 					TNSCanvas.nativeFlush(canvasView.nativeContext)
 					if (!mGLThread!!.getPaused() && !swapBuffers(mEGLSurface)) {
 						Log.e("JS", "GLContext: Cannot swap buffers!")
 					}
-					canvasView.pendingInvalidate = false
+					canvasView.invalidateState = TNSCanvas.InvalidateState.NONE
 				} else {
 					// WebGL
 					if (!mGLThread!!.getPaused() && !swapBuffers(mEGLSurface)) {
 						Log.e("JS", "GLContext: Cannot swap buffers!")
 					}
 					if (canvasView != null) {
-						canvasView.pendingInvalidate = false
+						canvasView.invalidateState = TNSCanvas.InvalidateState.NONE
 					}
 				}
 			}

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvas.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvas.kt
@@ -46,7 +46,7 @@ class TNSCanvas : FrameLayout, FrameCallback, ActivityLifecycleCallbacks {
 		}
 
 	@JvmField
-	internal var pendingInvalidate = false
+	internal var invalidateState = InvalidateState.NONE
 	internal var contextType = ContextType.NONE
 	internal var actualContextType = ""
 	internal var useCpu = false
@@ -122,9 +122,14 @@ class TNSCanvas : FrameLayout, FrameCallback, ActivityLifecycleCallbacks {
 
 	private val mainHandler = Handler(Looper.getMainLooper())
 
+	enum class InvalidateState {
+		NONE, PENDING, INVALIDATING
+	}
+
 	override fun doFrame(frameTimeNanos: Long) {
 		if (!isHandleInvalidationManually) {
-			if (pendingInvalidate) {
+			if (invalidateState == InvalidateState.PENDING) {
+				invalidateState = InvalidateState.INVALIDATING
 				flush()
 			}
 		}

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvasRenderingContext2D.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvasRenderingContext2D.kt
@@ -523,7 +523,7 @@ class TNSCanvasRenderingContext2D internal constructor(val canvas: TNSCanvas) :
 
 	private fun updateCanvas() {
 		// synchronized (canvasView.lock) {
-		canvas.pendingInvalidate = true
+		canvas.invalidateState = TNSCanvas.InvalidateState.PENDING
 		//}
 	}
 

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSWebGLRenderingContext.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSWebGLRenderingContext.kt
@@ -39,7 +39,7 @@ open class TNSWebGLRenderingContext : TNSCanvasRenderingContext {
 
 	fun updateCanvas() {
 		// synchronized (canvasView.lock) {
-		canvas.pendingInvalidate = true
+		canvas.invalidateState = TNSCanvas.InvalidateState.PENDING
 		//}
 	}
 

--- a/packages/canvas/typings/android.d.ts
+++ b/packages/canvas/typings/android.d.ts
@@ -309,7 +309,7 @@ declare module org {
 		export module canvas {
 			export class TNSCanvas {
 				public static class: java.lang.Class<org.nativescript.canvas.TNSCanvas>;
-				public pendingInvalidate: boolean;
+				public invalidateState: org.nativescript.canvas.TNSCanvas.ContextType;
 				public contextAlpha: boolean;
 				public contextAntialias: boolean;
 				public contextDepth: boolean;
@@ -458,6 +458,14 @@ declare module org {
 					});
 					public constructor();
 					public onResult(param0: string): void;
+				}
+				export class InvalidateState {
+					public static class: java.lang.Class<org.nativescript.canvas.TNSCanvas.InvalidateState>;
+					public static NONE: org.nativescript.canvas.TNSCanvas.InvalidateState;
+					public static PENDING: org.nativescript.canvas.TNSCanvas.InvalidateState;
+					public static INVALIDATING: org.nativescript.canvas.TNSCanvas.InvalidateState;
+					public static valueOf(param0: string): org.nativescript.canvas.TNSCanvas.InvalidateState;
+					public static values(): androidNative.Array<org.nativescript.canvas.TNSCanvas.InvalidateState>;
 				}
 				export class Listener {
 					public static class: java.lang.Class<org.nativescript.canvas.TNSCanvas.Listener>;


### PR DESCRIPTION
In android, there is a random bug that makes canvas blank.
There are references about it including mine in issue #67 .
This has discouraged me to use plugin so far because most of our clients have android phones.

Let's start with this. We have android `doFrame` callback to handle canvas invalidation.
That is an overridden method inside `TNSCanvas`: https://github.com/NativeScript/canvas/blob/master/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvas.kt#L125
```
        override fun doFrame(frameTimeNanos: Long) {
		if (!isHandleInvalidationManually) {
			if (pendingInvalidate) {
				flush() // THIS LINE IS VERY IMPORTANT REGARDING THIS BUG
			}
		}
		Choreographer.getInstance().postFrameCallback(this)
	}
```
Flush execution will indirectly call `GLContext` method `flush` that contains invalidation logic, wrapped inside  `queueEvent` method here: https://github.com/NativeScript/canvas/blob/master/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt#L148

The queue will eventually be handled from `GLThread` and execute invalidation logic here: https://github.com/NativeScript/canvas/blob/master/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt#L599
```
        while (true) {
		try {
			if (!isPaused) {
				makeEGLContextCurrent()
				mQueue.take().run()
			}
		} catch (e: InterruptedException) {
			break
		}
	}
```

So, where is the problem?
On a first look, this whole logic seems good. However, there is something really deceiving about it.
There is the call of `Choreographer.getInstance().postFrameCallback(this)` at the end of `doFrame` callback that performs the next call of `doFrame` itself.

The problem here is there is no guarantee that `postFrameCallback` will be executed once `flush` is done. After all, `flush` logic is inserted inside a `BlockingQueue` and another thread (`GLThread`) is pulling the event and running it inside thread's loop cycle.

As a result, frame callback can be called anew before `flush` is done and will attempt an additional flush causing a conflict between them.

So
```
        override fun doFrame(frameTimeNanos: Long) {
		if (!isHandleInvalidationManually) {
			if (pendingInvalidate) {
				flush() // THIS MAY NOT EXECUTE INSTANTLY
			}
		}
		Choreographer.getInstance().postFrameCallback(this) // AS A RESULT, THIS WILL EXECUTE SOONER
	}
```
The defect of this flaw is that it makes canvas completely blank. This bug is extremely random because the code itself is good but there is a flaw caused by multi-threading. I have personally dealt with Java threads for few years now and I can see the evil in them. 

I had to read native code and search a lot until I made the conclusion above, though I'm really excited about the time spent.
In order to fix this, I replaced `pendingInvalidate` with `invalidateState` flag which has 3 enum states (NONE, PENDING, INVALIDATING).
This flag keeps the old functionality and additionally lets canvas be aware if it's in the process of invalidating.

These changes seem fine to me regarding conventions but I'm not very familiar with kotlin, so please feel free to correct me if needed.