### PR TITLE
fix(android): Canvas was getting blank because of unexpected flush calls

### DIFF
--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/CPUView.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/CPUView.kt
@@ -69,9 +69,11 @@ class CPUView @JvmOverloads constructor(
 				canvasView?.get()?.let { canvas ->
 					if (canvas.nativeContext != 0L) {
 						canvas.queueEvent {
+							// We don't want pending flags that were set up to this point
+							canvas.invalidateState = canvas.invalidateState and TNSCanvas.INVALIDATE_STATE_PENDING.inv()
 							TNSCanvas.nativeCustomWithBitmapFlush(canvas.nativeContext, it)
 							handler!!.post {
-								canvas.invalidateState = TNSCanvas.InvalidateState.NONE
+								canvas.invalidateState = canvas.invalidateState and TNSCanvas.INVALIDATE_STATE_INVALIDATING.inv()
 								invalidate()
 							}
 						}

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
@@ -157,7 +157,6 @@ internal class GLContext {
 					if (!mGLThread!!.getPaused() && !swapBuffers(mEGLSurface)) {
 						Log.e("JS", "GLContext: Cannot swap buffers!")
 					}
-					// Do not completely unset flags as there might be a pending flag at this point
 					canvasView.invalidateState = canvasView.invalidateState and TNSCanvas.INVALIDATE_STATE_INVALIDATING.inv()
 				} else {
 					// WebGL

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/GLContext.kt
@@ -149,19 +149,24 @@ internal class GLContext {
 		queueEvent {
 			if (reference != null) {
 				val canvasView = reference!!.get()
-				if (canvasView != null && canvasView.nativeContext != 0L && canvasView.invalidateState == TNSCanvas.InvalidateState.INVALIDATING) {
+				if (canvasView != null && canvasView.nativeContext != 0L && (canvasView.invalidateState and TNSCanvas.INVALIDATE_STATE_INVALIDATING) == TNSCanvas.INVALIDATE_STATE_INVALIDATING) {
+					// We don't want pending flags that were set up to this point
+					canvasView.invalidateState = canvasView.invalidateState and TNSCanvas.INVALIDATE_STATE_PENDING.inv()
+
 					TNSCanvas.nativeFlush(canvasView.nativeContext)
 					if (!mGLThread!!.getPaused() && !swapBuffers(mEGLSurface)) {
 						Log.e("JS", "GLContext: Cannot swap buffers!")
 					}
-					canvasView.invalidateState = TNSCanvas.InvalidateState.NONE
+					// Do not completely unset flags as there might be a pending flag at this point
+					canvasView.invalidateState = canvasView.invalidateState and TNSCanvas.INVALIDATE_STATE_INVALIDATING.inv()
 				} else {
 					// WebGL
 					if (!mGLThread!!.getPaused() && !swapBuffers(mEGLSurface)) {
 						Log.e("JS", "GLContext: Cannot swap buffers!")
 					}
 					if (canvasView != null) {
-						canvasView.invalidateState = TNSCanvas.InvalidateState.NONE
+						// If this point is reached, it means something went wrong so set flag to none
+						canvasView.invalidateState = TNSCanvas.INVALIDATE_STATE_NONE
 					}
 				}
 			}

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvas.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvas.kt
@@ -46,7 +46,7 @@ class TNSCanvas : FrameLayout, FrameCallback, ActivityLifecycleCallbacks {
 		}
 
 	@JvmField
-	internal var invalidateState = InvalidateState.NONE
+	internal var invalidateState = TNSCanvas.INVALIDATE_STATE_NONE // bitwise flag
 	internal var contextType = ContextType.NONE
 	internal var actualContextType = ""
 	internal var useCpu = false
@@ -122,14 +122,11 @@ class TNSCanvas : FrameLayout, FrameCallback, ActivityLifecycleCallbacks {
 
 	private val mainHandler = Handler(Looper.getMainLooper())
 
-	enum class InvalidateState {
-		NONE, PENDING, INVALIDATING
-	}
-
 	override fun doFrame(frameTimeNanos: Long) {
 		if (!isHandleInvalidationManually) {
-			if (invalidateState == InvalidateState.PENDING) {
-				invalidateState = InvalidateState.INVALIDATING
+			// Only pending state flag is accepted
+			if (invalidateState == INVALIDATE_STATE_PENDING) {
+				invalidateState = INVALIDATE_STATE_INVALIDATING
 				flush()
 			}
 		}
@@ -599,6 +596,11 @@ class TNSCanvas : FrameLayout, FrameCallback, ActivityLifecycleCallbacks {
 
 	companion object {
 		var views: ConcurrentHashMap<*, *> = ConcurrentHashMap<Any?, Any?>()
+
+		// Invalidate state bitwise flags
+		internal const val INVALIDATE_STATE_NONE = 0
+		internal const val INVALIDATE_STATE_PENDING = 1
+		internal const val INVALIDATE_STATE_INVALIDATING = 2
 
 		@JvmStatic
 		fun layoutView(width: Int, height: Int, tnsCanvas: TNSCanvas) {

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvasRenderingContext2D.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSCanvasRenderingContext2D.kt
@@ -523,7 +523,7 @@ class TNSCanvasRenderingContext2D internal constructor(val canvas: TNSCanvas) :
 
 	private fun updateCanvas() {
 		// synchronized (canvasView.lock) {
-		canvas.invalidateState = TNSCanvas.InvalidateState.PENDING
+		canvas.invalidateState = canvas.invalidateState or TNSCanvas.INVALIDATE_STATE_PENDING
 		//}
 	}
 

--- a/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSWebGLRenderingContext.kt
+++ b/packages/canvas/src-native/canvas-android/canvas/src/main/java/org/nativescript/canvas/TNSWebGLRenderingContext.kt
@@ -39,7 +39,7 @@ open class TNSWebGLRenderingContext : TNSCanvasRenderingContext {
 
 	fun updateCanvas() {
 		// synchronized (canvasView.lock) {
-		canvas.invalidateState = TNSCanvas.InvalidateState.PENDING
+		canvas.invalidateState = canvas.invalidateState or TNSCanvas.INVALIDATE_STATE_PENDING
 		//}
 	}
 


### PR DESCRIPTION
It seems that current flag for `TNSCanvas` invalidation state was not covering all cases.
In particular, state was changed asynchronously due to `GLThread` and `Choreographer` being like 2 tasks running in parallel.

This caused multiple issues that resulted in more `flush` calls than expected or none at all, and this whole problem turned canvas blank as mentioned in #84 .
I updated old `TNSCanvas` property to use bitwise flags instead of enums to avoid doing multiple checks and support more things in the future.

This seems to completely fix the problem I mentioned.

