### PR TITLE
fix: Error when TouchManager calls addEventListener with name of type number.

### DIFF
--- a/packages/canvas/Canvas/common.ts
+++ b/packages/canvas/Canvas/common.ts
@@ -405,7 +405,9 @@ export abstract class CanvasBase extends View implements ICanvasBase {
 
 	public addEventListener(arg: string, callback: any, thisArg?: any) {
 		super.addEventListener(arg, callback, thisArg);
-
+		if (typeof arg !== 'string') {
+			return;
+		}
 		const eventtype = arg.toLowerCase();
 
 		switch (eventtype) {


### PR DESCRIPTION
#### Problem:
When an app using a global TouchManager is suspended and then resumed, the TouchManager triggers `canvas.addEventListener` with the type 'number' as the first argument, leading to an UncaughtJsExceptions.
```sh
  Error: Calling js method onStart failed
  TypeError: arg.toLowerCase is not a function
```
#### Solution:
Adding a conditional statement within the `addEventListener` extension in the `canvas` class. The modification ensures that the event type is a string.
