### PR TITLE
fix(webgpu): fixes per-frame memory growth

### DIFF
--- a/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
+++ b/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
@@ -1495,9 +1495,19 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_present_surface(
                             if error.is_none() {
                                 global.queue_submit(data.device.queue.queue.id, &[id]).ok();
                             }
+
+                            // Release the per-present read-back command buffer. Without
+                            // this it is retained in wgpu-core every frame, the dominant
+                            // render-proportional native-heap leak. Mirrors the drop in
+                            // gpu_queue.rs::queue_submit.
+                            global.command_buffer_drop(id);
                         }
                         Err(_) => {}
                     }
+
+                    // The read-back encoder is single-use per present; drop it so it is
+                    // not retained in wgpu-core's registry across frames.
+                    global.command_encoder_drop(encoder);
                 }
             }
         };

--- a/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
+++ b/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
@@ -1496,17 +1496,11 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_present_surface(
                                 global.queue_submit(data.device.queue.queue.id, &[id]).ok();
                             }
 
-                            // Release the per-present read-back command buffer. Without
-                            // this it is retained in wgpu-core every frame, the dominant
-                            // render-proportional native-heap leak. Mirrors the drop in
-                            // gpu_queue.rs::queue_submit.
                             global.command_buffer_drop(id);
                         }
                         Err(_) => {}
                     }
 
-                    // The read-back encoder is single-use per present; drop it so it is
-                    // not retained in wgpu-core's registry across frames.
                     global.command_encoder_drop(encoder);
                 }
             }

--- a/crates/canvas-c/src/webgpu/gpu_texture.rs
+++ b/crates/canvas-c/src/webgpu/gpu_texture.rs
@@ -50,22 +50,14 @@ impl Drop for CanvasGPUTexture {
                     .has_surface_presented
                     .load(std::sync::atomic::Ordering::SeqCst);
 
-                // If the frame was acquired but never presented, return the image to
-                // the swapchain so it can be reused. We are in Drop, so we cannot
-                // propagate or fatally abort on failure; log and continue to the drop.
+                // acquired but never presented: hand the image back to the swapchain
                 if !has_surface_presented {
                     if let Err(cause) = global.surface_texture_discard(surface_id) {
-                        log::warn!(
-                            "canvas: surface_texture_discard during texture drop failed: {cause:?}"
-                        );
+                        log::warn!("surface_texture_discard failed: {cause:?}");
                     }
                 }
 
-                // Free the wgpu Texture (and its surface `clear_view`) from the hub.
-                // present()/discard() only drop the acquired-texture ref; the hub
-                // registry holds a second ref that must be dropped here. Without this
-                // the per-frame swapchain texture and its clear image view leak in
-                // wgpu-core every frame (render-proportional native-heap growth).
+                // drop the hub ref so the surface texture and its clear_view are freed
                 global.texture_drop(self.texture);
                 self.surface_id = None;
             }

--- a/crates/canvas-c/src/webgpu/gpu_texture.rs
+++ b/crates/canvas-c/src/webgpu/gpu_texture.rs
@@ -45,28 +45,29 @@ impl Drop for CanvasGPUTexture {
         }
         match self.surface_id {
             Some(surface_id) => {
+                let global = self.instance.global();
                 let has_surface_presented = self
                     .has_surface_presented
                     .load(std::sync::atomic::Ordering::SeqCst);
 
+                // If the frame was acquired but never presented, return the image to
+                // the swapchain so it can be reused. We are in Drop, so we cannot
+                // propagate or fatally abort on failure; log and continue to the drop.
                 if !has_surface_presented {
-                    let global = self.instance.global();
-
-                    /*
-                    match global.surface_texture_discard(surface_id) {
-                        Ok(_) => {
-                            self.surface_id = None;
-                        }
-                        Err(cause) => {
-                            handle_error_fatal(
-                                global,
-                                cause,
-                                "canvas_native_webgpu_texture_release",
-                            )
-                        },
+                    if let Err(cause) = global.surface_texture_discard(surface_id) {
+                        log::warn!(
+                            "canvas: surface_texture_discard during texture drop failed: {cause:?}"
+                        );
                     }
-                    */
                 }
+
+                // Free the wgpu Texture (and its surface `clear_view`) from the hub.
+                // present()/discard() only drop the acquired-texture ref; the hub
+                // registry holds a second ref that must be dropped here. Without this
+                // the per-frame swapchain texture and its clear image view leak in
+                // wgpu-core every frame (render-proportional native-heap growth).
+                global.texture_drop(self.texture);
+                self.surface_id = None;
             }
             None => {
                 let context = self.instance.global();

--- a/packages/canvas/WebGPU/Constants.ts
+++ b/packages/canvas/WebGPU/Constants.ts
@@ -39,8 +39,5 @@ export const native_ = Symbol('[[native]]');
 export const mapState_ = Symbol('[[mapState]]');
 export const contextPtr_ = Symbol('[[contextPtr]]');
 export const adapter_ = Symbol('[[adapter]]');
-// Back-reference to the GPUCanvasContext stamped on the GPUTexture returned by
-// getCurrentTexture(). A view created from that texture registers itself with the
-// owning context so it can be released deterministically at that context's
-// presentSurface() (the swapchain view's spec-defined point of death).
+// owning GPUCanvasContext stamped on the getCurrentTexture() texture (for release at present)
 export const swapchainContext_ = Symbol('[[swapchainContext]]');

--- a/packages/canvas/WebGPU/Constants.ts
+++ b/packages/canvas/WebGPU/Constants.ts
@@ -39,3 +39,8 @@ export const native_ = Symbol('[[native]]');
 export const mapState_ = Symbol('[[mapState]]');
 export const contextPtr_ = Symbol('[[contextPtr]]');
 export const adapter_ = Symbol('[[adapter]]');
+// Back-reference to the GPUCanvasContext stamped on the GPUTexture returned by
+// getCurrentTexture(). A view created from that texture registers itself with the
+// owning context so it can be released deterministically at that context's
+// presentSurface() (the swapchain view's spec-defined point of death).
+export const swapchainContext_ = Symbol('[[swapchainContext]]');

--- a/packages/canvas/WebGPU/GPUCanvasContext.ts
+++ b/packages/canvas/WebGPU/GPUCanvasContext.ts
@@ -24,6 +24,12 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 	// isolate never drain each other's in-flight views. See _registerSwapchainView.
 	private _swapchainViews: GPUTextureView[] = [];
 
+	// The per-frame GPUTexture wrappers returned by getCurrentTexture(). The native
+	// surface releases its own acquire ref at present, but each JS wrapper holds its
+	// own Arc clone whose only other free path is the GC finalizer a tight loop
+	// starves. Released here at present (handle only, never a GPU destroy).
+	private _swapchainTextures: GPUTexture[] = [];
+
 	/** @internal Registered from GPUTexture.createView for swapchain-texture views. */
 	_registerSwapchainView(view: GPUTextureView) {
 		this._swapchainViews.push(view);
@@ -189,8 +195,10 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 			console.error('GPUCanvasContext.getCurrentTexture: native texture wrapper contained no texture');
 		} else {
 			// Stamp the owning context so a view created from this texture registers
-			// for deterministic release at this context's presentSurface().
+			// for deterministic release at this context's presentSurface(), and track
+			// the texture wrapper itself for handle release at present.
 			(result as any)[swapchainContext_] = this;
+			this._swapchainTextures.push(result);
 		}
 		return result;
 	}
@@ -210,6 +218,20 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 				view?.[native_]?.destroy?.();
 				if (view) {
 					view[native_] = null;
+				}
+			}
+		}
+		// Release the per-frame swapchain texture wrappers (handle only, not a GPU
+		// destroy). __releaseHandle is optional-chained so an un-rebuilt native falls
+		// back to the finalizer. See GPUTextureImpl::ReleaseHandle.
+		const texs = this._swapchainTextures;
+		if (texs.length > 0) {
+			this._swapchainTextures = [];
+			for (let i = 0; i < texs.length; i++) {
+				const tex = texs[i] as any;
+				tex?.[native_]?.__releaseHandle?.();
+				if (tex) {
+					tex[native_] = null;
 				}
 			}
 		}

--- a/packages/canvas/WebGPU/GPUCanvasContext.ts
+++ b/packages/canvas/WebGPU/GPUCanvasContext.ts
@@ -1,7 +1,8 @@
 import { Helpers } from '../helpers';
-import { adapter_, contextPtr_, GPUTextureUsage, native_ } from './Constants';
+import { adapter_, contextPtr_, GPUTextureUsage, native_, swapchainContext_ } from './Constants';
 import type { GPUDevice } from './GPUDevice';
 import { GPUTexture } from './GPUTexture';
+import type { GPUTextureView } from './GPUTextureView';
 import type { GPUAdapter } from './GPUAdapter';
 import type { GPUCanvasAlphaMode, GPUCanvasPresentMode, GPUExtent3D, GPUTextureFormat } from './Types';
 import type { CanvasRenderingContext } from '../common';
@@ -17,6 +18,16 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 
 	[native_] = null;
 	[contextPtr_] = null;
+
+	// Swapchain texture views created since the last present. Each dies at the next
+	// presentSurface(); held per-context (not globally) so multiple canvases in one
+	// isolate never drain each other's in-flight views. See _registerSwapchainView.
+	private _swapchainViews: GPUTextureView[] = [];
+
+	/** @internal Registered from GPUTexture.createView for swapchain-texture views. */
+	_registerSwapchainView(view: GPUTextureView) {
+		this._swapchainViews.push(view);
+	}
 
 	constructor(context: any, contextOptions: any = {}) {
 		let nativeContext = '0';
@@ -176,12 +187,32 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 		const result = GPUTexture.fromNative(texture);
 		if (!result) {
 			console.error('GPUCanvasContext.getCurrentTexture: native texture wrapper contained no texture');
+		} else {
+			// Stamp the owning context so a view created from this texture registers
+			// for deterministic release at this context's presentSurface().
+			(result as any)[swapchainContext_] = this;
 		}
 		return result;
 	}
 
 	presentSurface(_texture?: GPUTexture) {
 		this.native.presentSurface();
+		// Present is the swapchain view's point of death. Release this frame's views
+		// now instead of waiting for a GC sweep a tight render loop starves. The
+		// encoder, passes, and command buffer were already released at their own
+		// consumption points (finish/end/submit). destroy() is optional-chained so an
+		// un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		const views = this._swapchainViews;
+		if (views.length > 0) {
+			this._swapchainViews = [];
+			for (let i = 0; i < views.length; i++) {
+				const view = views[i] as any;
+				view?.[native_]?.destroy?.();
+				if (view) {
+					view[native_] = null;
+				}
+			}
+		}
 	}
 
 	getCapabilities(adapter: GPUAdapter): {

--- a/packages/canvas/WebGPU/GPUCanvasContext.ts
+++ b/packages/canvas/WebGPU/GPUCanvasContext.ts
@@ -19,18 +19,11 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 	[native_] = null;
 	[contextPtr_] = null;
 
-	// Swapchain texture views created since the last present. Each dies at the next
-	// presentSurface(); held per-context (not globally) so multiple canvases in one
-	// isolate never drain each other's in-flight views. See _registerSwapchainView.
+	// per-frame swapchain views and textures, released at the next presentSurface()
 	private _swapchainViews: GPUTextureView[] = [];
-
-	// The per-frame GPUTexture wrappers returned by getCurrentTexture(). The native
-	// surface releases its own acquire ref at present, but each JS wrapper holds its
-	// own Arc clone whose only other free path is the GC finalizer a tight loop
-	// starves. Released here at present (handle only, never a GPU destroy).
 	private _swapchainTextures: GPUTexture[] = [];
 
-	/** @internal Registered from GPUTexture.createView for swapchain-texture views. */
+	/** @internal */
 	_registerSwapchainView(view: GPUTextureView) {
 		this._swapchainViews.push(view);
 	}
@@ -194,9 +187,7 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 		if (!result) {
 			console.error('GPUCanvasContext.getCurrentTexture: native texture wrapper contained no texture');
 		} else {
-			// Stamp the owning context so a view created from this texture registers
-			// for deterministic release at this context's presentSurface(), and track
-			// the texture wrapper itself for handle release at present.
+			// mark as swapchain-owned and track for release at present
 			(result as any)[swapchainContext_] = this;
 			this._swapchainTextures.push(result);
 		}
@@ -205,11 +196,7 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 
 	presentSurface(_texture?: GPUTexture) {
 		this.native.presentSurface();
-		// Present is the swapchain view's point of death. Release this frame's views
-		// now instead of waiting for a GC sweep a tight render loop starves. The
-		// encoder, passes, and command buffer were already released at their own
-		// consumption points (finish/end/submit). destroy() is optional-chained so an
-		// un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		// release this frame's swapchain views and textures (their point of death)
 		const views = this._swapchainViews;
 		if (views.length > 0) {
 			this._swapchainViews = [];
@@ -221,9 +208,6 @@ export class GPUCanvasContext implements CanvasRenderingContext {
 				}
 			}
 		}
-		// Release the per-frame swapchain texture wrappers (handle only, not a GPU
-		// destroy). __releaseHandle is optional-chained so an un-rebuilt native falls
-		// back to the finalizer. See GPUTextureImpl::ReleaseHandle.
 		const texs = this._swapchainTextures;
 		if (texs.length > 0) {
 			this._swapchainTextures = [];

--- a/packages/canvas/WebGPU/GPUCommandEncoder.ts
+++ b/packages/canvas/WebGPU/GPUCommandEncoder.ts
@@ -190,7 +190,14 @@ export class GPUCommandEncoder {
 
 	finish(descriptor?: { label?: string }) {
 		const ret = this[native_].finish(descriptor);
-		return GPUCommandBuffer.fromNative(ret);
+		const buffer = GPUCommandBuffer.fromNative(ret);
+		// finish() consumes the encoder (WebGPU spec: it becomes invalid). Release
+		// the native handle now instead of waiting for a GC sweep a tight render
+		// loop starves. destroy() is optional-chained so an un-rebuilt native still
+		// falls back to the finalizer. See platforms/.../webgpu/ArcHandle.h.
+		this[native_]?.destroy?.();
+		this[native_] = null;
+		return buffer;
 	}
 
 	insertDebugMarker(markerLabel: string) {

--- a/packages/canvas/WebGPU/GPUCommandEncoder.ts
+++ b/packages/canvas/WebGPU/GPUCommandEncoder.ts
@@ -191,10 +191,7 @@ export class GPUCommandEncoder {
 	finish(descriptor?: { label?: string }) {
 		const ret = this[native_].finish(descriptor);
 		const buffer = GPUCommandBuffer.fromNative(ret);
-		// finish() consumes the encoder (WebGPU spec: it becomes invalid). Release
-		// the native handle now instead of waiting for a GC sweep a tight render
-		// loop starves. destroy() is optional-chained so an un-rebuilt native still
-		// falls back to the finalizer. See platforms/.../webgpu/ArcHandle.h.
+		// finish() consumes the encoder; release it now instead of waiting for GC
 		this[native_]?.destroy?.();
 		this[native_] = null;
 		return buffer;

--- a/packages/canvas/WebGPU/GPUComputePassEncoder.ts
+++ b/packages/canvas/WebGPU/GPUComputePassEncoder.ts
@@ -19,9 +19,7 @@ export class GPUComputePassEncoder {
 	}
 
 	end() {
-		// end() consumes the pass (WebGPU spec: it becomes invalid). Release the
-		// native handle now rather than waiting for GC. destroy() is optional-chained
-		// so an un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		// end() consumes the pass; release it now instead of waiting for GC
 		const n = this[native_];
 		n?.end();
 		n?.destroy?.();

--- a/packages/canvas/WebGPU/GPUComputePassEncoder.ts
+++ b/packages/canvas/WebGPU/GPUComputePassEncoder.ts
@@ -19,7 +19,12 @@ export class GPUComputePassEncoder {
 	}
 
 	end() {
-		this[native_].end();
+		// end() consumes the pass (WebGPU spec: it becomes invalid). Release the
+		// native handle now rather than waiting for GC. destroy() is optional-chained
+		// so an un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		const n = this[native_];
+		n?.end();
+		n?.destroy?.();
 		this[native_] = null;
 	}
 

--- a/packages/canvas/WebGPU/GPUQueue.ts
+++ b/packages/canvas/WebGPU/GPUQueue.ts
@@ -129,6 +129,17 @@ export class GPUQueue {
 					return command[native_];
 				}),
 			);
+			// submit() consumes the command buffers (WebGPU spec: they cannot be
+			// resubmitted). Release their native handles now rather than waiting for a
+			// GC sweep a tight render loop starves. destroy() is optional-chained so an
+			// un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+			for (let i = 0; i < commands.length; i++) {
+				const command = commands[i] as any;
+				command?.[native_]?.destroy?.();
+				if (command) {
+					command[native_] = null;
+				}
+			}
 		}
 	}
 

--- a/packages/canvas/WebGPU/GPUQueue.ts
+++ b/packages/canvas/WebGPU/GPUQueue.ts
@@ -129,10 +129,7 @@ export class GPUQueue {
 					return command[native_];
 				}),
 			);
-			// submit() consumes the command buffers (WebGPU spec: they cannot be
-			// resubmitted). Release their native handles now rather than waiting for a
-			// GC sweep a tight render loop starves. destroy() is optional-chained so an
-			// un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+			// submit() consumes the command buffers; release them now instead of via GC
 			for (let i = 0; i < commands.length; i++) {
 				const command = commands[i] as any;
 				command?.[native_]?.destroy?.();

--- a/packages/canvas/WebGPU/GPURenderPassEncoder.ts
+++ b/packages/canvas/WebGPU/GPURenderPassEncoder.ts
@@ -45,9 +45,7 @@ export class GPURenderPassEncoder {
 	}
 
 	end() {
-		// end() consumes the pass (WebGPU spec: it becomes invalid). Release the
-		// native handle now rather than waiting for GC. destroy() is optional-chained
-		// so an un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		// end() consumes the pass; release it now instead of waiting for GC
 		const n = this[native_];
 		n?.end();
 		n?.destroy?.();

--- a/packages/canvas/WebGPU/GPURenderPassEncoder.ts
+++ b/packages/canvas/WebGPU/GPURenderPassEncoder.ts
@@ -45,7 +45,13 @@ export class GPURenderPassEncoder {
 	}
 
 	end() {
-		this[native_].end();
+		// end() consumes the pass (WebGPU spec: it becomes invalid). Release the
+		// native handle now rather than waiting for GC. destroy() is optional-chained
+		// so an un-rebuilt native falls back to the finalizer. See ArcHandle.h.
+		const n = this[native_];
+		n?.end();
+		n?.destroy?.();
+		this[native_] = null;
 	}
 
 	endOcclusionQuery() {

--- a/packages/canvas/WebGPU/GPUTexture.ts
+++ b/packages/canvas/WebGPU/GPUTexture.ts
@@ -1,4 +1,4 @@
-import { native_ } from './Constants';
+import { native_, swapchainContext_ } from './Constants';
 import { GPUTextureView } from './GPUTextureView';
 import type { GPUTextureViewDescriptor } from './Interfaces';
 
@@ -49,6 +49,16 @@ export class GPUTexture {
 
 	createView(desc?: GPUTextureViewDescriptor) {
 		const view = this[native_].createView(desc);
-		return GPUTextureView.fromNative(view);
+		const ret = GPUTextureView.fromNative(view);
+		// A view of the swapchain current-texture dies at presentSurface(). Register
+		// it with the owning context so that context releases it deterministically.
+		// Views of persistent textures (render targets, depth) carry no context ref,
+		// are cached by three across frames, and must NOT be released here. See
+		// GPUCanvasContext.getCurrentTexture / presentSurface.
+		const ctx = (this as any)[swapchainContext_];
+		if (ret && ctx) {
+			ctx._registerSwapchainView(ret);
+		}
+		return ret;
 	}
 }

--- a/packages/canvas/WebGPU/GPUTexture.ts
+++ b/packages/canvas/WebGPU/GPUTexture.ts
@@ -50,11 +50,7 @@ export class GPUTexture {
 	createView(desc?: GPUTextureViewDescriptor) {
 		const view = this[native_].createView(desc);
 		const ret = GPUTextureView.fromNative(view);
-		// A view of the swapchain current-texture dies at presentSurface(). Register
-		// it with the owning context so that context releases it deterministically.
-		// Views of persistent textures (render targets, depth) carry no context ref,
-		// are cached by three across frames, and must NOT be released here. See
-		// GPUCanvasContext.getCurrentTexture / presentSurface.
+		// swapchain-texture views die at present; register them with the owning context
 		const ctx = (this as any)[swapchainContext_];
 		if (ret && ctx) {
 			ctx._registerSwapchainView(ret);

--- a/packages/canvas/WebGPU/GPUTextureView.ts
+++ b/packages/canvas/WebGPU/GPUTextureView.ts
@@ -7,6 +7,11 @@ export class GPUTextureView {
 		return this[native_]?.label ?? '';
 	}
 
+	// NOTE: deterministic release is not wired here. createView() runs for both
+	// swapchain and persistent textures, and three caches views of persistent
+	// render targets/depth textures across frames. Only swapchain-texture views
+	// die at present, so that release is scoped in GPUTexture.createView() ->
+	// GPUCanvasContext (see swapchainContext_).
 	static fromNative(view) {
 		if (view) {
 			const ret = new GPUTextureView();

--- a/packages/canvas/WebGPU/GPUTextureView.ts
+++ b/packages/canvas/WebGPU/GPUTextureView.ts
@@ -7,11 +7,6 @@ export class GPUTextureView {
 		return this[native_]?.label ?? '';
 	}
 
-	// NOTE: deterministic release is not wired here. createView() runs for both
-	// swapchain and persistent textures, and three caches views of persistent
-	// render targets/depth textures across frames. Only swapchain-texture views
-	// die at present, so that release is scoped in GPUTexture.createView() ->
-	// GPUCanvasContext (see swapchainContext_).
 	static fromNative(view) {
 		if (view) {
 			const ret = new GPUTextureView();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/ArcHandle.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/ArcHandle.h
@@ -1,0 +1,54 @@
+//
+// ArcHandle.h — RAII owner for the Rust Arc handles exposed across the canvas C ABI.
+//
+
+#ifndef CANVAS_WEBGPU_ARCHANDLE_H
+#define CANVAS_WEBGPU_ARCHANDLE_H
+
+#include <memory>
+
+// Every WebGPU wrapper owns one raw pointer to a refcounted Rust object. The
+// matching `..._release` C ABI function decrements that Arc exactly once. We hold
+// the pointer in a unique_ptr with a stateless custom deleter so the lifecycle is
+// a property of the type instead of a hand-written destructor plus an idempotency
+// flag:
+//
+//   - reset() runs the deleter once and nulls the pointer. That is the
+//     deterministic dispose, called at the WebGPU consumption point the spec
+//     already defines (pass.end(), encoder.finish(), queue.submit(), present()).
+//   - ~unique_ptr() invokes the deleter only when the pointer is non-null, so the
+//     GC finalizer that runs later is a guaranteed no-op. No double-decrement, no
+//     use-after-free, no flag to keep in sync.
+//
+// Decrementing our Arc share never frees a resource the GPU still needs: wgpu
+// holds its own strong refs to anything in flight (submitted command buffers, the
+// surface's current texture), so releasing at the consumption point is safe by the
+// Arc semantics.
+template <typename T, void (*Release)(const T *)>
+struct ArcDeleter {
+    void operator()(const T *ptr) const noexcept {
+        if (ptr != nullptr) {
+            Release(ptr);
+        }
+    }
+};
+
+template <typename T, void (*Release)(const T *)>
+using ArcHandle = std::unique_ptr<const T, ArcDeleter<T, Release>>;
+
+// Variant for the handful of C ABI release functions that take a non-const
+// pointer (e.g. the compilation-info/message and limits wrappers). Same
+// semantics; the only difference is the pointee constness.
+template <typename T, void (*Release)(T *)>
+struct MutArcDeleter {
+    void operator()(T *ptr) const noexcept {
+        if (ptr != nullptr) {
+            Release(ptr);
+        }
+    }
+};
+
+template <typename T, void (*Release)(T *)>
+using MutArcHandle = std::unique_ptr<T, MutArcDeleter<T, Release>>;
+
+#endif // CANVAS_WEBGPU_ARCHANDLE_H

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/ArcHandle.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/ArcHandle.h
@@ -7,23 +7,9 @@
 
 #include <memory>
 
-// Every WebGPU wrapper owns one raw pointer to a refcounted Rust object. The
-// matching `..._release` C ABI function decrements that Arc exactly once. We hold
-// the pointer in a unique_ptr with a stateless custom deleter so the lifecycle is
-// a property of the type instead of a hand-written destructor plus an idempotency
-// flag:
-//
-//   - reset() runs the deleter once and nulls the pointer. That is the
-//     deterministic dispose, called at the WebGPU consumption point the spec
-//     already defines (pass.end(), encoder.finish(), queue.submit(), present()).
-//   - ~unique_ptr() invokes the deleter only when the pointer is non-null, so the
-//     GC finalizer that runs later is a guaranteed no-op. No double-decrement, no
-//     use-after-free, no flag to keep in sync.
-//
-// Decrementing our Arc share never frees a resource the GPU still needs: wgpu
-// holds its own strong refs to anything in flight (submitted command buffers, the
-// surface's current texture), so releasing at the consumption point is safe by the
-// Arc semantics.
+// unique_ptr owner for a Rust Arc handle exposed across the C ABI. reset() runs the
+// matching ..._release once and nulls the pointer; the GC finalizer's later drop is
+// then a no-op. ArcHandle for const release fns, MutArcHandle for non-const.
 template <typename T, void (*Release)(const T *)>
 struct ArcDeleter {
     void operator()(const T *ptr) const noexcept {
@@ -36,9 +22,6 @@ struct ArcDeleter {
 template <typename T, void (*Release)(const T *)>
 using ArcHandle = std::unique_ptr<const T, ArcDeleter<T, Release>>;
 
-// Variant for the handful of C ABI release functions that take a non-const
-// pointer (e.g. the compilation-info/message and limits wrappers). Same
-// semantics; the only difference is the pointee constness.
 template <typename T, void (*Release)(T *)>
 struct MutArcDeleter {
     void operator()(T *ptr) const noexcept {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.cpp
@@ -8,7 +8,7 @@
 GPUAdapterImpl::GPUAdapterImpl(const CanvasGPUAdapter *adapter) : adapter_(adapter) {}
 
 const CanvasGPUAdapter *GPUAdapterImpl::GetGPUAdapter() {
-    return this->adapter_;
+    return this->adapter_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.h
@@ -8,6 +8,7 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 #include "GPUSupportedLimitsImpl.h"
 #include "GPUDeviceImpl.h"
 #include "GPUAdapterInfoImpl.h"
@@ -16,9 +17,7 @@ class GPUAdapterImpl : ObjectWrapperImpl {
 public:
     explicit GPUAdapterImpl(const CanvasGPUAdapter *adapter);
 
-    ~GPUAdapterImpl() {
-        canvas_native_webgpu_adapter_release(this->GetGPUAdapter());
-    }
+    ~GPUAdapterImpl() = default;
 
     const CanvasGPUAdapter *GetGPUAdapter();
 
@@ -56,7 +55,7 @@ public:
 
 
 private:
-    const CanvasGPUAdapter *adapter_;
+    ArcHandle<CanvasGPUAdapter, canvas_native_webgpu_adapter_release> adapter_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.cpp
@@ -8,7 +8,7 @@
 GPUAdapterInfoImpl::GPUAdapterInfoImpl(const CanvasGPUAdapterInfo *info) : info_(info) {}
 
 const CanvasGPUAdapterInfo *GPUAdapterInfoImpl::GetInfo() {
-    return this->info_;
+    return this->info_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUAdapterInfoImpl : ObjectWrapperImpl {
 public:
     explicit GPUAdapterInfoImpl(const CanvasGPUAdapterInfo *info);
 
-    ~GPUAdapterInfoImpl() {
-        canvas_native_webgpu_adapter_info_release(this->GetInfo());
-    }
+    ~GPUAdapterInfoImpl() = default;
 
     const CanvasGPUAdapterInfo *GetInfo();
 
@@ -51,7 +50,7 @@ public:
 
 
 private:
-    const CanvasGPUAdapterInfo *info_;
+    ArcHandle<CanvasGPUAdapterInfo, canvas_native_webgpu_adapter_info_release> info_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.cpp
@@ -9,7 +9,7 @@ GPUBindGroupImpl::GPUBindGroupImpl(const CanvasGPUBindGroup *groupLayout)
         : group_(groupLayout) {}
 
 const CanvasGPUBindGroup *GPUBindGroupImpl::GetBindGroup() {
-    return this->group_;
+    return this->group_.get();
 }
 
 
@@ -63,7 +63,7 @@ GPUBindGroupImpl::GetLabel(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_bind_group_get_label(ptr->group_);
+        auto label = canvas_native_webgpu_bind_group_get_label(ptr->group_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUBindGroupImpl : ObjectWrapperImpl {
 public:
     explicit GPUBindGroupImpl(const CanvasGPUBindGroup *group);
 
-    ~GPUBindGroupImpl() {
-        canvas_native_webgpu_bind_group_release(this->GetBindGroup());
-    }
+    ~GPUBindGroupImpl() = default;
 
     const CanvasGPUBindGroup *GetBindGroup();
 
@@ -41,7 +40,7 @@ public:
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
-    const CanvasGPUBindGroup *group_;
+    ArcHandle<CanvasGPUBindGroup, canvas_native_webgpu_bind_group_release> group_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.cpp
@@ -9,7 +9,7 @@ GPUBindGroupLayoutImpl::GPUBindGroupLayoutImpl(const CanvasGPUBindGroupLayout *g
         : groupLayout_(groupLayout) {}
 
 const CanvasGPUBindGroupLayout *GPUBindGroupLayoutImpl::GetBindGroupLayout() {
-    return this->groupLayout_;
+    return this->groupLayout_.get();
 }
 
 
@@ -63,7 +63,7 @@ GPUBindGroupLayoutImpl::GetLabel(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_bind_group_layout_get_label(ptr->groupLayout_);
+        auto label = canvas_native_webgpu_bind_group_layout_get_label(ptr->groupLayout_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUBindGroupLayoutImpl : ObjectWrapperImpl {
 public:
     explicit GPUBindGroupLayoutImpl(const CanvasGPUBindGroupLayout *groupLayout);
 
-    ~GPUBindGroupLayoutImpl() {
-        canvas_native_webgpu_bind_group_layout_release(this->GetBindGroupLayout());
-    }
+    ~GPUBindGroupLayoutImpl() = default;
 
     const CanvasGPUBindGroupLayout *GetBindGroupLayout();
 
@@ -41,7 +40,7 @@ public:
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
-    const CanvasGPUBindGroupLayout *groupLayout_;
+    ArcHandle<CanvasGPUBindGroupLayout, canvas_native_webgpu_bind_group_layout_release> groupLayout_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.cpp
@@ -8,7 +8,7 @@
 GPUBufferImpl::GPUBufferImpl(const CanvasGPUBuffer *buffer) : buffer_(buffer) {}
 
 const CanvasGPUBuffer *GPUBufferImpl::GetGPUBuffer() {
-    return this->buffer_;
+    return this->buffer_.get();
 }
 
 
@@ -261,7 +261,7 @@ GPUBufferImpl::GetLabel(v8::Local<v8::Name> name,
                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_buffer_get_label(ptr->buffer_);
+        auto label = canvas_native_webgpu_buffer_get_label(ptr->buffer_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.h
@@ -7,15 +7,14 @@
 
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 
 class GPUBufferImpl : ObjectWrapperImpl {
 public:
     explicit GPUBufferImpl(const CanvasGPUBuffer *buffer);
 
-    ~GPUBufferImpl() {
-        canvas_native_webgpu_buffer_release(this->GetGPUBuffer());
-    }
+    ~GPUBufferImpl() = default;
 
     const CanvasGPUBuffer *GetGPUBuffer();
 
@@ -56,7 +55,7 @@ public:
 
 
 private:
-    const CanvasGPUBuffer *buffer_;
+    ArcHandle<CanvasGPUBuffer, canvas_native_webgpu_buffer_release> buffer_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.cpp
@@ -32,7 +32,7 @@ GPUCanvasContextImpl::GPUCanvasContextImpl(const CanvasGPUCanvasContext *context
 																																														 }
 
 const CanvasGPUCanvasContext *GPUCanvasContextImpl::GetContext() {
-	return this->context_;
+	return this->context_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.h
@@ -10,6 +10,7 @@
 
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 #include "GPUDeviceImpl.h"
 #include "GPUTextureImpl.h"
 
@@ -51,8 +52,9 @@ public:
 	}
 	
 	~GPUCanvasContextImpl() {
+		// raf_ first (its callback can reference the context), then context_ is
+		// released by its ArcHandle member as this object is destroyed.
 		this->raf_.reset();
-		canvas_native_webgpu_context_release(this->context_);
 	}
 	
 	const CanvasGPUCanvasContext *GetContext();
@@ -102,7 +104,7 @@ public:
 	static void Flush(intptr_t context);
 	
 private:
-	const CanvasGPUCanvasContext *context_;
+	ArcHandle<CanvasGPUCanvasContext, canvas_native_webgpu_context_release> context_;
 	std::shared_ptr<RafImpl> raf_;
 	
 	bool continuousRender_ = true;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
@@ -10,7 +10,7 @@ GPUCommandBufferImpl::GPUCommandBufferImpl(const CanvasGPUCommandBuffer *command
         commandBuffer) {}
 
 const CanvasGPUCommandBuffer *GPUCommandBufferImpl::GetGPUCommandBuffer() {
-    return this->commandBuffer_;
+    return this->commandBuffer_.get();
 }
 
 
@@ -53,6 +53,10 @@ v8::Local<v8::FunctionTemplate> GPUCommandBufferImpl::GetCtor(v8::Isolate *isola
             GetLabel
     );
 
+    tmpl->Set(
+            ConvertToV8String(isolate, "destroy"),
+            v8::FunctionTemplate::New(isolate, &Destroy));
+
 
     cache->GPUCommandBufferTmpl =
             std::make_unique<v8::Persistent<v8::FunctionTemplate>>(isolate, ctorTmpl);
@@ -60,12 +64,22 @@ v8::Local<v8::FunctionTemplate> GPUCommandBufferImpl::GetCtor(v8::Isolate *isola
 }
 
 
+void GPUCommandBufferImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
+    // Deterministic dispose, called from JS at queue.submit() once the command
+    // buffer is consumed. Release() drops our Arc share via the ArcHandle; the GC
+    // finalizer that runs later is a no-op (the handle is already null).
+    auto ptr = GetPointer(args.This());
+    if (ptr != nullptr) {
+        ptr->Release();
+    }
+}
+
 void
 GPUCommandBufferImpl::GetLabel(v8::Local<v8::Name> name,
                                const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_command_buffer_get_label(ptr->commandBuffer_);
+        auto label = canvas_native_webgpu_command_buffer_get_label(ptr->commandBuffer_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
@@ -65,9 +65,6 @@ v8::Local<v8::FunctionTemplate> GPUCommandBufferImpl::GetCtor(v8::Isolate *isola
 
 
 void GPUCommandBufferImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
-    // Deterministic dispose, called from JS at queue.submit() once the command
-    // buffer is consumed. Release() drops our Arc share via the ArcHandle; the GC
-    // finalizer that runs later is a no-op (the handle is already null).
     auto ptr = GetPointer(args.This());
     if (ptr != nullptr) {
         ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.h
@@ -8,16 +8,18 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUCommandBufferImpl : ObjectWrapperImpl {
 public:
     explicit GPUCommandBufferImpl(const CanvasGPUCommandBuffer *commandBuffer);
 
-    ~GPUCommandBufferImpl() {
-        canvas_native_webgpu_command_buffer_release(this->commandBuffer_);
-    }
+    // Deterministic dispose, called from Destroy() at queue.submit(). See ArcHandle.h.
+    void Release() { commandBuffer_.reset(); }
 
     const CanvasGPUCommandBuffer *GetGPUCommandBuffer();
+
+    static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
@@ -41,7 +43,7 @@ public:
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
-    const CanvasGPUCommandBuffer *commandBuffer_;
+    ArcHandle<CanvasGPUCommandBuffer, canvas_native_webgpu_command_buffer_release> commandBuffer_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
@@ -17,7 +17,7 @@ GPUCommandEncoderImpl::GPUCommandEncoderImpl(const CanvasGPUCommandEncoder *enco
 																																																encoder) {}
 
 const CanvasGPUCommandEncoder *GPUCommandEncoderImpl::GetEncoder() {
-	return this->encoder_;
+	return this->encoder_.get();
 }
 
 void GPUCommandEncoderImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate) {
@@ -110,11 +110,25 @@ v8::Local<v8::FunctionTemplate> GPUCommandEncoderImpl::GetCtor(v8::Isolate *isol
 	tmpl->Set(
 						ConvertToV8String(isolate, "writeTimestamp"),
 						v8::FunctionTemplate::New(isolate, &WriteTimestamp));
-	
-	
+
+	tmpl->Set(
+						ConvertToV8String(isolate, "destroy"),
+						v8::FunctionTemplate::New(isolate, &Destroy));
+
+
 	cache->GPUCommandEncoderTmpl =
 	std::make_unique<v8::Persistent<v8::FunctionTemplate>>(isolate, ctorTmpl);
 	return ctorTmpl;
+}
+
+void GPUCommandEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
+	// Deterministic per-frame free. A command encoder is single-use: it is
+	// finished (encoder.finish()) and the resulting buffer submitted before
+	// presentSurface(), so it is safe to drop at the frame boundary.
+	auto ptr = GetPointer(args.This());
+	if (ptr != nullptr) {
+		ptr->Release();
+	}
 }
 
 void
@@ -122,7 +136,7 @@ GPUCommandEncoderImpl::GetLabel(v8::Local<v8::Name> name,
 																const v8::PropertyCallbackInfo<v8::Value> &info) {
 	auto ptr = GetPointer(info.This());
 	if (ptr != nullptr) {
-		auto label = canvas_native_webgpu_command_encoder_get_label(ptr->encoder_);
+		auto label = canvas_native_webgpu_command_encoder_get_label(ptr->encoder_.get());
 		if (label == nullptr) {
 			info.GetReturnValue().SetEmptyString();
 			return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
@@ -122,9 +122,6 @@ v8::Local<v8::FunctionTemplate> GPUCommandEncoderImpl::GetCtor(v8::Isolate *isol
 }
 
 void GPUCommandEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
-	// Deterministic per-frame free. A command encoder is single-use: it is
-	// finished (encoder.finish()) and the resulting buffer submitted before
-	// presentSurface(), so it is safe to drop at the frame boundary.
 	auto ptr = GetPointer(args.This());
 	if (ptr != nullptr) {
 		ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.h
@@ -8,16 +8,18 @@
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
 #include "GPUUtils.h"
+#include "ArcHandle.h"
 
 class GPUCommandEncoderImpl : ObjectWrapperImpl {
 public:
     explicit GPUCommandEncoderImpl(const CanvasGPUCommandEncoder *encoder);
 
-    ~GPUCommandEncoderImpl() {
-        canvas_native_webgpu_command_encoder_release(this->encoder_);
-    }
+    // Deterministic dispose, called from Destroy() at encoder.finish(). See ArcHandle.h.
+    void Release() { encoder_.reset(); }
 
     const CanvasGPUCommandEncoder *GetEncoder();
+
+    static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
@@ -66,7 +68,7 @@ public:
     static void WriteTimestamp(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 private:
-    const CanvasGPUCommandEncoder *encoder_;
+    ArcHandle<CanvasGPUCommandEncoder, canvas_native_webgpu_command_encoder_release> encoder_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.cpp
@@ -10,7 +10,7 @@ GPUCompilationInfoImpl::GPUCompilationInfoImpl(CanvasGPUCompilationInfo *info) :
         info) {}
 
 CanvasGPUCompilationInfo *GPUCompilationInfoImpl::GetCompilationInfo() {
-    return this->info_;
+    return this->info_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUCompilationInfoImpl : ObjectWrapperImpl {
 public:
     explicit GPUCompilationInfoImpl(CanvasGPUCompilationInfo *info);
 
-    ~GPUCompilationInfoImpl() {
-        canvas_native_webgpu_compilation_info_release(this->GetCompilationInfo());
-    }
+    ~GPUCompilationInfoImpl() = default;
 
     CanvasGPUCompilationInfo* GetCompilationInfo();
 
@@ -42,7 +41,7 @@ public:
 
 
 private:
-    CanvasGPUCompilationInfo *info_;
+    MutArcHandle<CanvasGPUCompilationInfo, canvas_native_webgpu_compilation_info_release> info_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.cpp
@@ -10,7 +10,7 @@ GPUCompilationMessageImpl::GPUCompilationMessageImpl(CanvasGPUCompilationMessage
         message) {}
 
 CanvasGPUCompilationMessage *GPUCompilationMessageImpl::GetMessage() {
-    return this->message_;
+    return this->message_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUCompilationMessageImpl : ObjectWrapperImpl {
 public:
     explicit GPUCompilationMessageImpl(CanvasGPUCompilationMessage *message);
 
-    ~GPUCompilationMessageImpl() {
-        canvas_native_webgpu_compilation_message_release(this->GetMessage());
-    }
+    ~GPUCompilationMessageImpl() = default;
 
     CanvasGPUCompilationMessage *GetMessage();
 
@@ -57,7 +56,7 @@ public:
 
 
 private:
-    CanvasGPUCompilationMessage *message_;
+    MutArcHandle<CanvasGPUCompilationMessage, canvas_native_webgpu_compilation_message_release> message_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
@@ -13,7 +13,7 @@ GPUComputePassEncoderImpl::GPUComputePassEncoderImpl(const CanvasGPUComputePassE
         pass) {}
 
 const CanvasGPUComputePassEncoder *GPUComputePassEncoderImpl::GetComputePass() {
-    return this->computePass_;
+    return this->computePass_.get();
 }
 
 
@@ -90,6 +90,10 @@ v8::Local<v8::FunctionTemplate> GPUComputePassEncoderImpl::GetCtor(v8::Isolate *
             ConvertToV8String(isolate, "setPipeline"),
             v8::FunctionTemplate::New(isolate, &SetPipeline));
 
+    tmpl->Set(
+            ConvertToV8String(isolate, "destroy"),
+            v8::FunctionTemplate::New(isolate, &Destroy));
+
 
     cache->GPUComputePassEncoderTmpl =
             std::make_unique<v8::Persistent<v8::FunctionTemplate>>
@@ -97,12 +101,22 @@ v8::Local<v8::FunctionTemplate> GPUComputePassEncoderImpl::GetCtor(v8::Isolate *
     return ctorTmpl;
 }
 
+void GPUComputePassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
+    // Deterministic per-frame free. A compute pass is ended and its parent
+    // encoder finished+submitted before presentSurface(); single-use per WebGPU
+    // semantics, so dropping it at the frame boundary is safe.
+    auto ptr = GetPointer(args.This());
+    if (ptr != nullptr) {
+        ptr->Release();
+    }
+}
+
 void
 GPUComputePassEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_compute_pass_encoder_get_label(ptr->computePass_);
+        auto label = canvas_native_webgpu_compute_pass_encoder_get_label(ptr->computePass_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
@@ -102,9 +102,6 @@ v8::Local<v8::FunctionTemplate> GPUComputePassEncoderImpl::GetCtor(v8::Isolate *
 }
 
 void GPUComputePassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
-    // Deterministic per-frame free. A compute pass is ended and its parent
-    // encoder finished+submitted before presentSurface(); single-use per WebGPU
-    // semantics, so dropping it at the frame boundary is safe.
     auto ptr = GetPointer(args.This());
     if (ptr != nullptr) {
         ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.h
@@ -7,16 +7,18 @@
 
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUComputePassEncoderImpl : ObjectWrapperImpl {
 public:
     explicit GPUComputePassEncoderImpl(const CanvasGPUComputePassEncoder *computePass);
 
-    ~GPUComputePassEncoderImpl() {
-        canvas_native_webgpu_compute_pass_encoder_release(this->computePass_);
-    }
+    // Deterministic dispose, called from Destroy() at pass.end(). See ArcHandle.h.
+    void Release() { computePass_.reset(); }
 
     const CanvasGPUComputePassEncoder *GetComputePass();
+
+    static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
@@ -58,7 +60,7 @@ public:
 
 
 private:
-    const CanvasGPUComputePassEncoder *computePass_;
+    ArcHandle<CanvasGPUComputePassEncoder, canvas_native_webgpu_compute_pass_encoder_release> computePass_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.cpp
@@ -11,7 +11,7 @@ GPUComputePipelineImpl::GPUComputePipelineImpl(const CanvasGPUComputePipeline *p
         pipeline) {}
 
 const CanvasGPUComputePipeline *GPUComputePipelineImpl::GetGPUPipeline() {
-    return this->pipeline_;
+    return this->pipeline_.get();
 }
 
 
@@ -68,7 +68,7 @@ GPUComputePipelineImpl::GetLabel(v8::Local<v8::Name> name,
                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_compute_pipeline_get_label(ptr->pipeline_);
+        auto label = canvas_native_webgpu_compute_pipeline_get_label(ptr->pipeline_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUComputePipelineImpl : ObjectWrapperImpl {
 public:
     explicit GPUComputePipelineImpl(const CanvasGPUComputePipeline *pipeline);
 
-    ~GPUComputePipelineImpl() {
-        canvas_native_webgpu_compute_pipeline_release(this->pipeline_);
-    }
+    ~GPUComputePipelineImpl() = default;
 
     const CanvasGPUComputePipeline *GetGPUPipeline();
 
@@ -44,7 +43,7 @@ public:
 
 
 private:
-    const CanvasGPUComputePipeline *pipeline_;
+    ArcHandle<CanvasGPUComputePipeline, canvas_native_webgpu_compute_pipeline_release> pipeline_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.cpp
@@ -26,7 +26,7 @@
 GPUDeviceImpl::GPUDeviceImpl(const CanvasGPUDevice *device) : device_(device) {}
 
 const CanvasGPUDevice *GPUDeviceImpl::GetGPUDevice() {
-    return this->device_;
+    return this->device_.get();
 }
 
 
@@ -173,7 +173,7 @@ GPUDeviceImpl::GetLabel(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_device_get_label(ptr->device_);
+        auto label = canvas_native_webgpu_device_get_label(ptr->device_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUDeviceImpl : ObjectWrapperImpl {
 public:
     explicit GPUDeviceImpl(const CanvasGPUDevice *device);
 
-    ~GPUDeviceImpl() {
-        canvas_native_webgpu_device_release(this->device_);
-    }
+    ~GPUDeviceImpl() = default;
 
     const CanvasGPUDevice *GetGPUDevice();
 
@@ -90,7 +89,7 @@ public:
 
 
 private:
-    const CanvasGPUDevice *device_;
+    ArcHandle<CanvasGPUDevice, canvas_native_webgpu_device_release> device_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.cpp
@@ -8,7 +8,7 @@
 GPUImpl::GPUImpl(const CanvasWebGPUInstance *instance) : instance_(instance) {}
 
 const CanvasWebGPUInstance *GPUImpl::GetGPUInstance() {
-    return this->instance_;
+    return this->instance_.get();
 }
 
 void GPUImpl::Init(const v8::Local<v8::Object> &canvasModule, v8::Isolate *isolate) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.h
@@ -9,17 +9,13 @@
 #include "Helpers.h"
 #include "GPUAdapterImpl.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUImpl : ObjectWrapperImpl {
 public:
     explicit GPUImpl(const CanvasWebGPUInstance *instance);
 
-    ~GPUImpl() {
-        if (this->instance_ != nullptr) {
-            canvas_native_webgpu_instance_release(this->instance_);
-            this->instance_ = nullptr;
-        }
-    }
+    ~GPUImpl() = default;
 
     const CanvasWebGPUInstance *GetGPUInstance();
 
@@ -48,7 +44,7 @@ public:
     static void RequestAdapter(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 private:
-    const CanvasWebGPUInstance *instance_;
+    ArcHandle<CanvasWebGPUInstance, canvas_native_webgpu_instance_release> instance_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.cpp
@@ -9,7 +9,7 @@ GPUPipelineLayoutImpl::GPUPipelineLayoutImpl(const CanvasGPUPipelineLayout *pipe
         pipeline) {}
 
 const CanvasGPUPipelineLayout *GPUPipelineLayoutImpl::GetPipeline() {
-    return this->pipeline_;
+    return this->pipeline_.get();
 }
 
 
@@ -63,7 +63,7 @@ GPUPipelineLayoutImpl::GetLabel(v8::Local<v8::Name> name,
                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_pipeline_layout_get_label(ptr->pipeline_);
+        auto label = canvas_native_webgpu_pipeline_layout_get_label(ptr->pipeline_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.h
@@ -8,15 +8,14 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 
 class GPUPipelineLayoutImpl : ObjectWrapperImpl {
 public:
     explicit GPUPipelineLayoutImpl(const CanvasGPUPipelineLayout *pipeline);
 
-    ~GPUPipelineLayoutImpl() {
-        canvas_native_webgpu_pipeline_layout_release(this->GetPipeline());
-    }
+    ~GPUPipelineLayoutImpl() = default;
 
     const CanvasGPUPipelineLayout *GetPipeline();
 
@@ -42,7 +41,7 @@ public:
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
-    const CanvasGPUPipelineLayout *pipeline_;
+    ArcHandle<CanvasGPUPipelineLayout, canvas_native_webgpu_pipeline_layout_release> pipeline_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.cpp
@@ -8,7 +8,7 @@
 GPUQuerySetImpl::GPUQuerySetImpl(const CanvasGPUQuerySet *querySet) : querySet_(querySet) {}
 
 const CanvasGPUQuerySet *GPUQuerySetImpl::GetQuerySet() {
-    return this->querySet_;
+    return this->querySet_.get();
 }
 
 
@@ -131,6 +131,6 @@ void GPUQuerySetImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
     if (ptr == nullptr) {
         return;
     }
-    canvas_native_webgpu_query_set_destroy(ptr->querySet_);
+    canvas_native_webgpu_query_set_destroy(ptr->querySet_.get());
 
 }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.h
@@ -7,14 +7,13 @@
 
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUQuerySetImpl : ObjectWrapperImpl {
 public:
     explicit GPUQuerySetImpl(const CanvasGPUQuerySet *querySet);
 
-    ~GPUQuerySetImpl() {
-        canvas_native_webgpu_query_set_release(this->GetQuerySet());
-    }
+    ~GPUQuerySetImpl() = default;
 
     const CanvasGPUQuerySet *GetQuerySet();
 
@@ -48,7 +47,7 @@ public:
 
 
 private:
-    const CanvasGPUQuerySet *querySet_;
+    ArcHandle<CanvasGPUQuerySet, canvas_native_webgpu_query_set_release> querySet_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.cpp
@@ -17,7 +17,7 @@
 GPUQueueImpl::GPUQueueImpl(const CanvasGPUQueue *queue) : queue_(queue) {}
 
 const CanvasGPUQueue *GPUQueueImpl::GetGPUQueue() {
-    return this->queue_;
+    return this->queue_.get();
 }
 
 
@@ -94,7 +94,7 @@ GPUQueueImpl::GetLabel(v8::Local<v8::Name> name,
                        const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_queue_get_label(ptr->queue_);
+        auto label = canvas_native_webgpu_queue_get_label(ptr->queue_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.h
@@ -8,15 +8,14 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 #include "GPUUtils.h"
 
 class GPUQueueImpl : ObjectWrapperImpl {
 public:
     explicit GPUQueueImpl(const CanvasGPUQueue *queue);
 
-    ~GPUQueueImpl() {
-        canvas_native_webgpu_queue_release(this->GetGPUQueue());
-    }
+    ~GPUQueueImpl() = default;
 
     const CanvasGPUQueue *GetGPUQueue();
 
@@ -52,7 +51,7 @@ public:
 
 
 private:
-    const CanvasGPUQueue *queue_;
+    ArcHandle<CanvasGPUQueue, canvas_native_webgpu_queue_release> queue_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.cpp
@@ -15,7 +15,7 @@ GPURenderBundleEncoderImpl::GPURenderBundleEncoderImpl(const CanvasGPURenderBund
         encoder) {}
 
 const CanvasGPURenderBundleEncoder *GPURenderBundleEncoderImpl::GetEncoder() {
-    return this->encoder_;
+    return this->encoder_.get();
 }
 
 
@@ -121,7 +121,7 @@ GPURenderBundleEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_render_bundle_encoder_get_label(ptr->encoder_);
+        auto label = canvas_native_webgpu_render_bundle_encoder_get_label(ptr->encoder_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.h
@@ -8,15 +8,14 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPURenderBundleEncoderImpl : ObjectWrapperImpl {
 
 public:
     explicit GPURenderBundleEncoderImpl(const CanvasGPURenderBundleEncoder *encoder);
 
-    ~GPURenderBundleEncoderImpl() {
-        canvas_native_webgpu_render_bundle_encoder_release(this->GetEncoder());
-    }
+    ~GPURenderBundleEncoderImpl() = default;
 
     const CanvasGPURenderBundleEncoder *GetEncoder();
 
@@ -67,7 +66,7 @@ public:
 
 
 private:
-    const CanvasGPURenderBundleEncoder *encoder_;
+    ArcHandle<CanvasGPURenderBundleEncoder, canvas_native_webgpu_render_bundle_encoder_release> encoder_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.cpp
@@ -9,7 +9,7 @@ GPURenderBundleImpl::GPURenderBundleImpl(const CanvasGPURenderBundle *bundle) : 
         bundle) {}
 
 const CanvasGPURenderBundle *GPURenderBundleImpl::GetBundle() {
-    return this->bundle_;
+    return this->bundle_.get();
 }
 
 
@@ -62,7 +62,7 @@ GPURenderBundleImpl::GetLabel(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_render_bundle_get_label(ptr->bundle_);
+        auto label = canvas_native_webgpu_render_bundle_get_label(ptr->bundle_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPURenderBundleImpl : ObjectWrapperImpl {
 public:
     explicit GPURenderBundleImpl(const CanvasGPURenderBundle *bundle);
 
-    ~GPURenderBundleImpl() {
-        canvas_native_webgpu_render_bundle_release(this->bundle_);
-    }
+    ~GPURenderBundleImpl() = default;
 
     const CanvasGPURenderBundle *GetBundle();
 
@@ -41,7 +40,7 @@ public:
 
 
 private:
-    const CanvasGPURenderBundle *bundle_;
+    ArcHandle<CanvasGPURenderBundle, canvas_native_webgpu_render_bundle_release> bundle_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
@@ -14,7 +14,7 @@ GPURenderPassEncoderImpl::GPURenderPassEncoderImpl(const CanvasGPURenderPassEnco
         pass) {}
 
 const CanvasGPURenderPassEncoder *GPURenderPassEncoderImpl::GetPass() {
-    return this->pass_;
+    return this->pass_.get();
 }
 
 
@@ -143,18 +143,32 @@ v8::Local<v8::FunctionTemplate> GPURenderPassEncoderImpl::GetCtor(v8::Isolate *i
             ConvertToV8String(isolate, "setViewport"),
             v8::FunctionTemplate::New(isolate, &SetViewport));
 
+    tmpl->Set(
+            ConvertToV8String(isolate, "destroy"),
+            v8::FunctionTemplate::New(isolate, &Destroy));
+
     cache->GPURenderPassEncoderTmpl =
             std::make_unique<v8::Persistent<v8::FunctionTemplate>>(isolate, ctorTmpl);
     return ctorTmpl;
 }
 
 
+void GPURenderPassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
+    // Deterministic per-frame free. A render pass is ended (pass.end()) and its
+    // parent encoder finished+submitted before presentSurface(); the pass is
+    // single-use per WebGPU semantics, so dropping it at the frame boundary is safe.
+    auto ptr = GetPointer(args.This());
+    if (ptr != nullptr) {
+        ptr->Release();
+    }
+}
+
 void
 GPURenderPassEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                    const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_render_pass_encoder_get_label(ptr->pass_);
+        auto label = canvas_native_webgpu_render_pass_encoder_get_label(ptr->pass_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
@@ -154,9 +154,6 @@ v8::Local<v8::FunctionTemplate> GPURenderPassEncoderImpl::GetCtor(v8::Isolate *i
 
 
 void GPURenderPassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
-    // Deterministic per-frame free. A render pass is ended (pass.end()) and its
-    // parent encoder finished+submitted before presentSurface(); the pass is
-    // single-use per WebGPU semantics, so dropping it at the frame boundary is safe.
     auto ptr = GetPointer(args.This());
     if (ptr != nullptr) {
         ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.h
@@ -9,16 +9,18 @@
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
 #include "GPUUtils.h"
+#include "ArcHandle.h"
 
 class GPURenderPassEncoderImpl : ObjectWrapperImpl {
 public:
     explicit GPURenderPassEncoderImpl(const CanvasGPURenderPassEncoder *pass);
 
-    ~GPURenderPassEncoderImpl() {
-        canvas_native_webgpu_render_pass_encoder_release(this->GetPass());
-    }
+    // Deterministic dispose, called from Destroy() at pass.end(). See ArcHandle.h.
+    void Release() { pass_.reset(); }
 
     const CanvasGPURenderPassEncoder *GetPass();
+
+    static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
@@ -85,7 +87,7 @@ public:
 
 
 private:
-    const CanvasGPURenderPassEncoder *pass_;
+    ArcHandle<CanvasGPURenderPassEncoder, canvas_native_webgpu_render_pass_encoder_release> pass_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.cpp
@@ -10,7 +10,7 @@ GPURenderPipelineImpl::GPURenderPipelineImpl(const CanvasGPURenderPipeline *pipe
         pipeline) {}
 
 const CanvasGPURenderPipeline *GPURenderPipelineImpl::GetGPUPipeline() {
-    return this->pipeline_;
+    return this->pipeline_.get();
 }
 
 
@@ -92,7 +92,7 @@ GPURenderPipelineImpl::GetLabel(v8::Local<v8::Name> name,
                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_render_pipeline_get_label(ptr->pipeline_);
+        auto label = canvas_native_webgpu_render_pipeline_get_label(ptr->pipeline_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPURenderPipelineImpl : ObjectWrapperImpl {
 public:
     explicit GPURenderPipelineImpl(const CanvasGPURenderPipeline *pipeline);
 
-    ~GPURenderPipelineImpl() {
-        canvas_native_webgpu_render_pipeline_release(this->pipeline_);
-    }
+    ~GPURenderPipelineImpl() = default;
 
     const CanvasGPURenderPipeline *GetGPUPipeline();
 
@@ -45,7 +44,7 @@ public:
 
 
 private:
-    const CanvasGPURenderPipeline *pipeline_;
+    ArcHandle<CanvasGPURenderPipeline, canvas_native_webgpu_render_pipeline_release> pipeline_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.cpp
@@ -9,7 +9,7 @@ GPUSamplerImpl::GPUSamplerImpl(const CanvasGPUSampler *sampler) : sampler_(
         sampler) {}
 
 const CanvasGPUSampler *GPUSamplerImpl::GetSampler() {
-    return this->sampler_;
+    return this->sampler_.get();
 }
 
 
@@ -63,7 +63,7 @@ GPUSamplerImpl::GetLabel(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_sampler_get_label(ptr->sampler_);
+        auto label = canvas_native_webgpu_sampler_get_label(ptr->sampler_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUSamplerImpl : ObjectWrapperImpl {
 public:
     explicit GPUSamplerImpl(const CanvasGPUSampler *sampler);
 
-    ~GPUSamplerImpl() {
-        canvas_native_webgpu_sampler_release(this->sampler_);
-    }
+    ~GPUSamplerImpl() = default;
 
     const CanvasGPUSampler *GetSampler();
 
@@ -41,7 +40,7 @@ public:
 
 
 private:
-    const CanvasGPUSampler *sampler_;
+    ArcHandle<CanvasGPUSampler, canvas_native_webgpu_sampler_release> sampler_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.cpp
@@ -10,7 +10,7 @@ GPUShaderModuleImpl::GPUShaderModuleImpl(const CanvasGPUShaderModule *shaderModu
         shaderModule) {}
 
 const CanvasGPUShaderModule *GPUShaderModuleImpl::GetShaderModule() {
-    return this->shaderModule_;
+    return this->shaderModule_.get();
 }
 
 
@@ -67,7 +67,7 @@ GPUShaderModuleImpl::GetLabel(v8::Local<v8::Name> name,
                               const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_shader_module_get_label(ptr->shaderModule_);
+        auto label = canvas_native_webgpu_shader_module_get_label(ptr->shaderModule_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUShaderModuleImpl : ObjectWrapperImpl {
 public:
     explicit GPUShaderModuleImpl(const CanvasGPUShaderModule *shaderModule);
 
-    ~GPUShaderModuleImpl() {
-        canvas_native_webgpu_shader_module_release(this->GetShaderModule());
-    }
+    ~GPUShaderModuleImpl() = default;
 
     const CanvasGPUShaderModule *GetShaderModule();
 
@@ -43,7 +42,7 @@ public:
     static void GetCompilationInfo(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 private:
-    const CanvasGPUShaderModule *shaderModule_;
+    ArcHandle<CanvasGPUShaderModule, canvas_native_webgpu_shader_module_release> shaderModule_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.cpp
@@ -9,7 +9,7 @@ GPUSupportedLimitsImpl::GPUSupportedLimitsImpl(CanvasGPUSupportedLimits *limits)
         limits) {}
 
 CanvasGPUSupportedLimits *GPUSupportedLimitsImpl::GetLimits() {
-    return this->limits_;
+    return this->limits_.get();
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.h
@@ -7,14 +7,13 @@
 
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUSupportedLimitsImpl : public ObjectWrapperImpl {
 public:
     explicit GPUSupportedLimitsImpl(CanvasGPUSupportedLimits *limits);
 
-    ~GPUSupportedLimitsImpl() {
-        canvas_native_webgpu_limits_release(this->limits_);
-    }
+    ~GPUSupportedLimitsImpl() = default;
 
     CanvasGPUSupportedLimits *GetLimits();
 
@@ -281,7 +280,7 @@ public:
                                          const v8::PropertyCallbackInfo<void> &info);
 
 private:
-    CanvasGPUSupportedLimits *limits_;
+    MutArcHandle<CanvasGPUSupportedLimits, canvas_native_webgpu_limits_release> limits_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
@@ -261,10 +261,6 @@ void GPUTextureImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
 
 void GPUTextureImpl::ReleaseHandle(const v8::FunctionCallbackInfo<v8::Value> &args) {
-    // Drops the wrapper's Arc reference only (NOT a GPU destroy). Called from
-    // GPUCanvasContext.presentSurface() on the per-frame swapchain texture so its
-    // native handle is freed deterministically instead of waiting for the GC
-    // finalizer a tight render loop starves.
     GPUTextureImpl *ptr = GetPointer(args.This());
     if (ptr != nullptr) {
         ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
@@ -57,6 +57,10 @@ v8::Local<v8::FunctionTemplate> GPUTextureImpl::GetCtor(v8::Isolate *isolate) {
             ConvertToV8String(isolate, "destroy"),
             v8::FunctionTemplate::New(isolate, &Destroy));
 
+    tmpl->Set(
+            ConvertToV8String(isolate, "__releaseHandle"),
+            v8::FunctionTemplate::New(isolate, &ReleaseHandle));
+
 
     tmpl->SetLazyDataProperty(
             ConvertToV8String(isolate, "width"),
@@ -253,6 +257,18 @@ void GPUTextureImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
         return;
     }
     canvas_native_webgpu_texture_destroy(ptr->GetTexture());
+}
+
+
+void GPUTextureImpl::ReleaseHandle(const v8::FunctionCallbackInfo<v8::Value> &args) {
+    // Drops the wrapper's Arc reference only (NOT a GPU destroy). Called from
+    // GPUCanvasContext.presentSurface() on the per-frame swapchain texture so its
+    // native handle is freed deterministically instead of waiting for the GC
+    // finalizer a tight render loop starves.
+    GPUTextureImpl *ptr = GetPointer(args.This());
+    if (ptr != nullptr) {
+        ptr->Release();
+    }
 }
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
@@ -10,7 +10,7 @@
 GPUTextureImpl::GPUTextureImpl(const CanvasGPUTexture *texture) : texture_(texture) {}
 
 const CanvasGPUTexture *GPUTextureImpl::GetTexture() {
-    return this->texture_;
+    return this->texture_.get();
 }
 
 
@@ -118,7 +118,7 @@ GPUTextureImpl::GetLabel(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_texture_get_label(ptr->texture_);
+        auto label = canvas_native_webgpu_texture_get_label(ptr->texture_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
@@ -18,11 +18,7 @@ public:
 
     const CanvasGPUTexture *GetTexture();
 
-    // Drops our Arc reference to the texture (canvas_native_webgpu_texture_release
-    // via the ArcHandle deleter). This is NOT destroy(): it does not free the GPU
-    // texture, it only releases the wrapper's handle. Used to deterministically free
-    // the per-frame swapchain GPUTexture returned by getCurrentTexture() at present,
-    // whose only other free path is the starved GC finalizer. See ReleaseHandle.
+    // drops the wrapper's Arc handle (not destroy(), which frees the GPU texture)
     void Release() { texture_.reset(); }
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
@@ -73,8 +69,7 @@ public:
 
     static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    // JS-exposed as __releaseHandle: drops the wrapper's Arc handle (see Release).
-    // Distinct from destroy() so the swapchain texture's GPU memory is never freed.
+    // JS __releaseHandle: drops the wrapper's handle without destroying the texture
     static void ReleaseHandle(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void CreateView(const v8::FunctionCallbackInfo<v8::Value> &args);

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
@@ -18,6 +18,13 @@ public:
 
     const CanvasGPUTexture *GetTexture();
 
+    // Drops our Arc reference to the texture (canvas_native_webgpu_texture_release
+    // via the ArcHandle deleter). This is NOT destroy(): it does not free the GPU
+    // texture, it only releases the wrapper's handle. Used to deterministically free
+    // the per-frame swapchain GPUTexture returned by getCurrentTexture() at present,
+    // whose only other free path is the starved GC finalizer. See ReleaseHandle.
+    void Release() { texture_.reset(); }
+
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
     static GPUTextureImpl *GetPointer(const v8::Local<v8::Object> &object);
@@ -65,6 +72,10 @@ public:
                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
     static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
+
+    // JS-exposed as __releaseHandle: drops the wrapper's Arc handle (see Release).
+    // Distinct from destroy() so the swapchain texture's GPU memory is never freed.
+    static void ReleaseHandle(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void CreateView(const v8::FunctionCallbackInfo<v8::Value> &args);
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
@@ -8,14 +8,13 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUTextureImpl : ObjectWrapperImpl {
 public:
     explicit GPUTextureImpl(const CanvasGPUTexture *texture);
 
-    ~GPUTextureImpl() {
-        canvas_native_webgpu_texture_release(this->GetTexture());
-    }
+    ~GPUTextureImpl() = default;
 
     const CanvasGPUTexture *GetTexture();
 
@@ -70,7 +69,7 @@ public:
     static void CreateView(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 private:
-    const CanvasGPUTexture *texture_;
+    ArcHandle<CanvasGPUTexture, canvas_native_webgpu_texture_release> texture_;
 };
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
@@ -63,10 +63,6 @@ v8::Local<v8::FunctionTemplate> GPUTextureViewImpl::GetCtor(v8::Isolate *isolate
 
 
 void GPUTextureViewImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
-    // Deterministic per-frame free, driven by GPUCanvasContext.presentSurface().
-    // GPUTextureView is a transient single-frame ephemeral; the WebGPU integration
-    // (three/r3f) never keeps it across frames. Release() is idempotent so the
-    // later GC finalizer is a no-op.
     auto ptr = GetPointer(args.This());
     if (ptr != nullptr) {
         ptr->Release();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
@@ -8,7 +8,7 @@
 GPUTextureViewImpl::GPUTextureViewImpl(const CanvasGPUTextureView *view) : view_(view) {}
 
 const CanvasGPUTextureView *GPUTextureViewImpl::GetTextureView() {
-    return this->view_;
+    return this->view_.get();
 }
 
 
@@ -51,6 +51,10 @@ v8::Local<v8::FunctionTemplate> GPUTextureViewImpl::GetCtor(v8::Isolate *isolate
             GetLabel
     );
 
+    tmpl->Set(
+            ConvertToV8String(isolate, "destroy"),
+            v8::FunctionTemplate::New(isolate, &Destroy));
+
 
     cache->GPUTextureViewTmpl =
             std::make_unique<v8::Persistent<v8::FunctionTemplate>>(isolate, ctorTmpl);
@@ -58,12 +62,23 @@ v8::Local<v8::FunctionTemplate> GPUTextureViewImpl::GetCtor(v8::Isolate *isolate
 }
 
 
+void GPUTextureViewImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args) {
+    // Deterministic per-frame free, driven by GPUCanvasContext.presentSurface().
+    // GPUTextureView is a transient single-frame ephemeral; the WebGPU integration
+    // (three/r3f) never keeps it across frames. Release() is idempotent so the
+    // later GC finalizer is a no-op.
+    auto ptr = GetPointer(args.This());
+    if (ptr != nullptr) {
+        ptr->Release();
+    }
+}
+
 void
 GPUTextureViewImpl::GetLabel(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto ptr = GetPointer(info.This());
     if (ptr != nullptr) {
-        auto label = canvas_native_webgpu_texture_view_get_label(ptr->view_);
+        auto label = canvas_native_webgpu_texture_view_get_label(ptr->view_.get());
         if (label == nullptr) {
             info.GetReturnValue().SetEmptyString();
             return;

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
@@ -14,8 +14,7 @@ class GPUTextureViewImpl : ObjectWrapperImpl {
 public:
     explicit GPUTextureViewImpl(const CanvasGPUTextureView *view);
 
-    // Deterministic dispose, called from Destroy() at the present() boundary. The
-    // ArcHandle deleter handles the GC-finalizer case; see ArcHandle.h.
+    // deterministic dispose, called from Destroy() at present
     void Release() { view_.reset(); }
 
     const CanvasGPUTextureView *GetTextureView();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
@@ -8,16 +8,19 @@
 #include "Common.h"
 #include "Helpers.h"
 #include "ObjectWrapperImpl.h"
+#include "ArcHandle.h"
 
 class GPUTextureViewImpl : ObjectWrapperImpl {
 public:
     explicit GPUTextureViewImpl(const CanvasGPUTextureView *view);
 
-    ~GPUTextureViewImpl() {
-        canvas_native_webgpu_texture_view_release(this->GetTextureView());
-    }
+    // Deterministic dispose, called from Destroy() at the present() boundary. The
+    // ArcHandle deleter handles the GC-finalizer case; see ArcHandle.h.
+    void Release() { view_.reset(); }
 
     const CanvasGPUTextureView *GetTextureView();
+
+    static void Destroy(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate);
 
@@ -41,7 +44,7 @@ public:
 
 
 private:
-    const CanvasGPUTextureView *view_;
+    ArcHandle<CanvasGPUTextureView, canvas_native_webgpu_texture_view_release> view_;
 };
 
 


### PR DESCRIPTION
Fixes a slow steady memory growth leak discovered through an accidental soak test. I left the device running for several hours and came back to a low framerate. Ran heap snapshots in incremental waves sniping the offenders until heap growth was stable while rendering at 60-120fps.

Fixes #141.

I did not run an exhaustive search across all renderering implementations to verify memory leaks outside of WebGPU. This fix targets iOS and Android via the WebGPU rendering backend.

| BEFORE | AFTER |
| -------- | ------- |
| <video src="https://github.com/user-attachments/assets/dab3a03e-3c56-4f02-bacf-df0aa86dc7bc" controls preload></video> | <video src="https://github.com/user-attachments/assets/453a3dcb-a4be-43ef-ab76-a1b5cf69b4cf" controls preload></video> |

## Copilot Summary

This pull request introduces significant improvements to resource management and memory safety in the WebGPU implementation, especially regarding swapchain textures, command buffers, and the C++/Rust interface on iOS. The main themes are: (1) explicit and timely resource cleanup in the JavaScript/TypeScript bindings, (2) improved handling of swapchain textures and views, and (3) a safer, RAII-based approach to managing Rust Arc handles in the iOS C++ layer.

**Resource Management Improvements (JS/TS):**
- Explicitly release command encoders, command buffers, passes, and queue-submitted commands immediately after use, instead of relying on garbage collection. This reduces memory usage and prevents resource leaks. [[1]](diffhunk://#diff-be4bee9f2331e78d4138e2968e9e06b5bffb4bf856a336dbc04a64cc0459d134L193-R197) [[2]](diffhunk://#diff-83e71c5f1728a600d14f5dfc599c0118f24c8a5d2d1865a49760cf61bfe350e3R132-R139) [[3]](diffhunk://#diff-ad1f6d7d84e4b708390d8ca73ac12d2005f1de7f7f1584ef0b4cc9237c1c3bfbL22-R25) [[4]](diffhunk://#diff-b115c1ff53ec7f43b9200d5a52ae7a567d1a25099a803a9133f417e70e8c44dbL48-R52)
- Swapchain textures and their views are now tracked per frame and explicitly released at the end of each present cycle, ensuring they are not leaked and are returned to the swapchain promptly. [[1]](diffhunk://#diff-2e7a001a948367d10b5d8f2a244f1208828a996185f69ce61b0f75f605cc20d6R22-R30) [[2]](diffhunk://#diff-2e7a001a948367d10b5d8f2a244f1208828a996185f69ce61b0f75f605cc20d6R189-R221) [[3]](diffhunk://#diff-bac4adbb17018329a68de0b3c347c68d73cb45e8b2713e22fc49fccbcaa6be24L52-R58) [[4]](diffhunk://#diff-ed540da357384a1d60801bd74b723899ea29914c501c2a62744913fe86e0e47dR42-R43)

**Native Resource Cleanup (Rust/C++/iOS):**
- Introduced an `ArcHandle` RAII wrapper in C++ for Rust Arc handles exposed via the C ABI, replacing manual release calls in destructors and reducing the risk of double-free or leaks. Updated all relevant iOS WebGPU wrapper classes to use this pattern. [[1]](diffhunk://#diff-2d34c6fc1143a972643c22d8e6fd8c105a18c9e658a18184fe29282706bf2ff2R1-R37) [[2]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaR11) [[3]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaL19-R20) [[4]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaL59-R58) [[5]](diffhunk://#diff-66d4ff1b3fd808aa30b7847e053969e9ba32dd9cc830d88287ebbab369c8c28bL11-R11) [[6]](diffhunk://#diff-94d8bd0d53a8fa3fa614ff2a274f8c0d07c33eaee96b9a887e0bbc5b240d7236R11-R17) [[7]](diffhunk://#diff-94d8bd0d53a8fa3fa614ff2a274f8c0d07c33eaee96b9a887e0bbc5b240d7236L54-R53) [[8]](diffhunk://#diff-821d9d007081706f20230a8fa73ea61fc6bc2730dd49932ab7fcc6ea75a77564L12-R12) [[9]](diffhunk://#diff-821d9d007081706f20230a8fa73ea61fc6bc2730dd49932ab7fcc6ea75a77564L66-R66) [[10]](diffhunk://#diff-c04b4905e0175baba6107d27e577a33bb4ae2fd7386eb18edf054fd3bf071c4bR11-R17) [[11]](diffhunk://#diff-c04b4905e0175baba6107d27e577a33bb4ae2fd7386eb18edf054fd3bf071c4bL44-R43) [[12]](diffhunk://#diff-40b5ee133b63d255c5362ed60515266ca72aeebd0625e644035cef26d9ffbc89L12-R12) [[13]](diffhunk://#diff-40b5ee133b63d255c5362ed60515266ca72aeebd0625e644035cef26d9ffbc89L66-R66) [[14]](diffhunk://#diff-dfc3a908810ddbda2498f843e8467bbc10ad9f9948e725d80a07d1ec8f3504dcR11-R17) [[15]](diffhunk://#diff-dfc3a908810ddbda2498f843e8467bbc10ad9f9948e725d80a07d1ec8f3504dcL44-R43) [[16]](diffhunk://#diff-90934c90be4d2449aeea7de99d9d7e5361e7bac5ca099324537b4fafbc6ac99cL11-R11) [[17]](diffhunk://#diff-90934c90be4d2449aeea7de99d9d7e5361e7bac5ca099324537b4fafbc6ac99cL264-R264) [[18]](diffhunk://#diff-883b6db5bf0d983b13c81fc542e796635b03fe15235f5fe571e6c78518b1408dR10-R17)

**Swapchain Texture Lifecycle (Rust):**
- Ensured that command buffers and encoders are dropped promptly after presentation, and that swapchain textures are properly returned to the swapchain if not presented, further reducing the risk of resource leaks or undefined behavior. [[1]](diffhunk://#diff-1fa81004f45ce01c983626a62d90f4740a74df3e5e22d2f8c40ffaf3a92bc511R1498-R1504) [[2]](diffhunk://#diff-8119e571841ba1e5eabb28a1ef0185e91fce160d44724d5674f9a3ea1f683ecbR48-R62)

**Summary of Key Changes:**

**1. Resource Management and Cleanup (JS/TS):**
- Explicitly destroy or release command encoders, command buffers, compute/render passes, and queue-submitted commands immediately after use, clearing their native references. [[1]](diffhunk://#diff-be4bee9f2331e78d4138e2968e9e06b5bffb4bf856a336dbc04a64cc0459d134L193-R197) [[2]](diffhunk://#diff-83e71c5f1728a600d14f5dfc599c0118f24c8a5d2d1865a49760cf61bfe350e3R132-R139) [[3]](diffhunk://#diff-ad1f6d7d84e4b708390d8ca73ac12d2005f1de7f7f1584ef0b4cc9237c1c3bfbL22-R25) [[4]](diffhunk://#diff-b115c1ff53ec7f43b9200d5a52ae7a567d1a25099a803a9133f417e70e8c44dbL48-R52)
- Track swapchain textures and views per frame in `GPUCanvasContext`, and release them at `presentSurface()` to prevent leaks and ensure timely return to the swapchain. [[1]](diffhunk://#diff-2e7a001a948367d10b5d8f2a244f1208828a996185f69ce61b0f75f605cc20d6R22-R30) [[2]](diffhunk://#diff-2e7a001a948367d10b5d8f2a244f1208828a996185f69ce61b0f75f605cc20d6R189-R221) [[3]](diffhunk://#diff-bac4adbb17018329a68de0b3c347c68d73cb45e8b2713e22fc49fccbcaa6be24L52-R58) [[4]](diffhunk://#diff-ed540da357384a1d60801bd74b723899ea29914c501c2a62744913fe86e0e47dR42-R43)

**2. Rust/C++/iOS Interop Safety:**
- Added `ArcHandle.h` and refactored all iOS C++ WebGPU wrapper classes to use RAII for Rust Arc handles, eliminating manual release calls and improving safety. [[1]](diffhunk://#diff-2d34c6fc1143a972643c22d8e6fd8c105a18c9e658a18184fe29282706bf2ff2R1-R37) [[2]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaR11) [[3]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaL19-R20) [[4]](diffhunk://#diff-5eb6fe65d552c76dc9a2c8ebe9896c591a91edd3f05ba673121a0ada2a42dddaL59-R58) [[5]](diffhunk://#diff-66d4ff1b3fd808aa30b7847e053969e9ba32dd9cc830d88287ebbab369c8c28bL11-R11) [[6]](diffhunk://#diff-94d8bd0d53a8fa3fa614ff2a274f8c0d07c33eaee96b9a887e0bbc5b240d7236R11-R17) [[7]](diffhunk://#diff-94d8bd0d53a8fa3fa614ff2a274f8c0d07c33eaee96b9a887e0bbc5b240d7236L54-R53) [[8]](diffhunk://#diff-821d9d007081706f20230a8fa73ea61fc6bc2730dd49932ab7fcc6ea75a77564L12-R12) [[9]](diffhunk://#diff-821d9d007081706f20230a8fa73ea61fc6bc2730dd49932ab7fcc6ea75a77564L66-R66) [[10]](diffhunk://#diff-c04b4905e0175baba6107d27e577a33bb4ae2fd7386eb18edf054fd3bf071c4bR11-R17) [[11]](diffhunk://#diff-c04b4905e0175baba6107d27e577a33bb4ae2fd7386eb18edf054fd3bf071c4bL44-R43) [[12]](diffhunk://#diff-40b5ee133b63d255c5362ed60515266ca72aeebd0625e644035cef26d9ffbc89L12-R12) [[13]](diffhunk://#diff-40b5ee133b63d255c5362ed60515266ca72aeebd0625e644035cef26d9ffbc89L66-R66) [[14]](diffhunk://#diff-dfc3a908810ddbda2498f843e8467bbc10ad9f9948e725d80a07d1ec8f3504dcR11-R17) [[15]](diffhunk://#diff-dfc3a908810ddbda2498f843e8467bbc10ad9f9948e725d80a07d1ec8f3504dcL44-R43) [[16]](diffhunk://#diff-90934c90be4d2449aeea7de99d9d7e5361e7bac5ca099324537b4fafbc6ac99cL11-R11) [[17]](diffhunk://#diff-90934c90be4d2449aeea7de99d9d7e5361e7bac5ca099324537b4fafbc6ac99cL264-R264) [[18]](diffhunk://#diff-883b6db5bf0d983b13c81fc542e796635b03fe15235f5fe571e6c78518b1408dR10-R17)

**3. Swapchain Texture Handling (Rust):**
- Ensure command buffers and encoders are dropped after use, and swapchain textures are returned to the swapchain if never presented, logging warnings if discard fails. [[1]](diffhunk://#diff-1fa81004f45ce01c983626a62d90f4740a74df3e5e22d2f8c40ffaf3a92bc511R1498-R1504) [[2]](diffhunk://#diff-8119e571841ba1e5eabb28a1ef0185e91fce160d44724d5674f9a3ea1f683ecbR48-R62)

These changes collectively improve memory safety, performance, and reliability of the WebGPU implementation across platforms.