### PR TITLE
feat(tvos): add Canvas platform support

### DIFF
--- a/CanvasNative.podspec
+++ b/CanvasNative.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
     s.author       = { "Osei Fortune" => "fortune.osei@yahoo.com" }
 
-    s.platforms    = { :ios => "13.0", :visionos => "1.0" }
+    s.platforms    = { :ios => "13.0", :tvos => "13.0", :visionos => "1.0" }
 
     s.source       = { :git => "https://github.com/nativescript/canvas.git", :tag => "#{s.version}" }
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
 ARCHS_VISIONOS = aarch64-apple-visionos aarch64-apple-visionos-sim
+ARCHS_TVOS = aarch64-apple-tvos aarch64-apple-tvos-sim
 ARCHS_ANDROID = i686-linux-android x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 
 XCFRAMEWORK = CanvasNative.xcframework
@@ -10,6 +11,8 @@ all: GENERATE_HEADERS ios android
 ios: $(XCFRAMEWORK)
 
 visionos: $(ARCHS_VISIONOS)
+
+tvos: $(ARCHS_TVOS)
 
 android: GENERATE_ANDROID
 
@@ -35,6 +38,12 @@ $(XCFRAMEWORK): $(ARCHS_IOS)
 
 .PHONY: $(ARCHS_VISIONOS)
 $(ARCHS_VISIONOS): %:
+	RUSTFLAGS="-Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort" \
+	cargo +nightly build -Z build-std='std,panic_abort' \
+	    --target $@ --release -p canvas-ios
+
+.PHONY: $(ARCHS_TVOS)
+$(ARCHS_TVOS): %:
 	RUSTFLAGS="-Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort" \
 	cargo +nightly build -Z build-std='std,panic_abort' \
 	    --target $@ --release -p canvas-ios

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 
 let package = Package(
     name: "CanvasNative",
-    platforms: [.iOS(.v12), .visionOS(.v1)],
+    platforms: [.iOS(.v12), .tvOS(.v12), .visionOS(.v1)],
     products: [
         .library(name: "NativeScriptV8", targets: ["NativeScriptV8"]),
     ],

--- a/crates/canvas-2d/Cargo.toml
+++ b/crates/canvas-2d/Cargo.toml
@@ -26,7 +26,7 @@ raw-window-handle.workspace = true
 bitflags = "2.6.0"
 regex-lite = { workspace = true }
 
-[target.'cfg(any(target_os = "ios", target_os="macos", target_os = "visionos"))'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os="macos", target_os = "visionos", target_os = "tvos"))'.dependencies]
 foreign-types-shared = "0.3.1"
 objc2 = {workspace = true}
 objc2-foundation = { workspace = true }

--- a/crates/canvas-2d/src/context/drawing_images/mod.rs
+++ b/crates/canvas-2d/src/context/drawing_images/mod.rs
@@ -191,7 +191,7 @@ impl Context {
     }
 
     pub fn draw_image_dx_dy(&mut self, image: &Image, x: f32, y: f32) {
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
         let _ = unsafe { objc2_foundation::NSAutoreleasePool::new() };
         #[cfg(feature = "gl")]
         {
@@ -221,7 +221,7 @@ impl Context {
     }
 
     fn draw_image(&mut self, image: &Image, src_rect: impl Into<Rect>, dst_rect: impl Into<Rect>) {
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
         let _ = unsafe { objc2_foundation::NSAutoreleasePool::new() };
         #[cfg(feature = "gl")]
         {
@@ -259,7 +259,7 @@ impl Context {
     }
 
     fn draw_image_with_rect(&mut self, image: &Image, dst_rect: impl Into<Rect>) {
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
         let _ = unsafe { objc2_foundation::NSAutoreleasePool::new() };
         #[cfg(feature = "gl")]
         {

--- a/crates/canvas-2d/src/context/drawing_paths/mod.rs
+++ b/crates/canvas-2d/src/context/drawing_paths/mod.rs
@@ -12,7 +12,7 @@ impl Context {
         path: Option<&mut Path>,
         fill_rule: Option<FillRule>,
     ) {
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
         let _ = unsafe { objc2_foundation::NSAutoreleasePool::new() };
 
         #[cfg(feature = "gl")]

--- a/crates/canvas-2d/src/lib.rs
+++ b/crates/canvas-2d/src/lib.rs
@@ -101,7 +101,7 @@ pub fn bytes_to_data_n32_url(
     encoded_prefix.push_str(format);
     encoded_prefix.push_str(";base64,");
 
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
     let fmt = ColorType::BGRA8888;
 
     #[cfg(any(target_os = "android"))]

--- a/crates/canvas-c/Cargo.toml
+++ b/crates/canvas-c/Cargo.toml
@@ -44,7 +44,7 @@ objc2-metal = { workspace = true }
 
 # visionOS: display-link 0.2 is gated to ios/macos only, so RAF uses a CADisplayLink
 # shim (see src/raf/visionos.rs) built directly on objc2-quartz-core instead.
-[target.'cfg(target_os="visionos")'.dependencies]
+[target.'cfg(any(target_os="visionos", target_os="tvos"))'.dependencies]
 wgpu-core = { workspace = true, features = ["wgsl", "metal"] }
 wgpu-hal = { workspace = true, features = ["metal"] }
 objc2 = { workspace = true, features = ["std"] }

--- a/crates/canvas-c/src/c2d/context.rs
+++ b/crates/canvas-c/src/c2d/context.rs
@@ -290,7 +290,7 @@ impl CanvasRenderingContext2D {
 }
 
 /* Raf */
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_create(
     callback: isize,
@@ -305,7 +305,7 @@ pub extern "C" fn canvas_native_raf_create(
     ))))))
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_release(value: *mut crate::Raf) {
     if value.is_null() {
@@ -319,7 +319,7 @@ pub extern "C" fn canvas_native_raf_release(value: *mut crate::Raf) {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_start(raf: *mut crate::Raf) {
     if raf.is_null() {
@@ -329,7 +329,7 @@ pub extern "C" fn canvas_native_raf_start(raf: *mut crate::Raf) {
     raf.0.start();
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_stop(raf: *mut crate::Raf) {
     if raf.is_null() {
@@ -339,7 +339,7 @@ pub extern "C" fn canvas_native_raf_stop(raf: *mut crate::Raf) {
     raf.0.stop()
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_get_started(raf: *const crate::Raf) -> bool {
     if raf.is_null() {
@@ -349,7 +349,7 @@ pub extern "C" fn canvas_native_raf_get_started(raf: *const crate::Raf) -> bool 
     raf.0.started()
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_stop_and_clear(raf: *mut crate::Raf, timeout_ms: u64) {
     if raf.is_null() {
@@ -361,7 +361,7 @@ pub extern "C" fn canvas_native_raf_stop_and_clear(raf: *mut crate::Raf, timeout
     raf.0.clear_callback();
 }
 
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_raf_clear_callback(raf: *mut crate::Raf) {
     if raf.is_null() {

--- a/crates/canvas-c/src/lib.rs
+++ b/crates/canvas-c/src/lib.rs
@@ -28,7 +28,7 @@ mod helper;
 pub use helper::*;
 mod image_asset;
 pub use image_asset::*;
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 mod raf;
 mod text_decoder;
 pub use text_decoder::*;
@@ -38,7 +38,7 @@ mod webgl;
 pub use webgl::*;
 pub mod impl_test;
 /* Raf */
-#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[derive(Clone)]
 pub struct Raf(raf::Raf);
 /* Raf */

--- a/crates/canvas-c/src/raf/mod.rs
+++ b/crates/canvas-c/src/raf/mod.rs
@@ -10,7 +10,7 @@ mod ios;
 pub use ios::*;
 
 // visionOS has no display-link crate support; use a CADisplayLink-backed RAF instead.
-#[cfg(target_os = "visionos")]
+#[cfg(any(target_os = "visionos", target_os = "tvos"))]
 mod visionos;
-#[cfg(target_os = "visionos")]
+#[cfg(any(target_os = "visionos", target_os = "tvos"))]
 pub use visionos::*;

--- a/crates/canvas-c/src/webgpu/gpu.rs
+++ b/crates/canvas-c/src/webgpu/gpu.rs
@@ -93,7 +93,7 @@ pub type WebGPUInstance = Arc<CanvasWebGPUInstance>;
 
 #[no_mangle]
 pub extern "C" fn canvas_native_webgpu_instance_create() -> *const CanvasWebGPUInstance {
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
     let backends = wgt::Backends::METAL;
 
     #[cfg(target_os = "android")]
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_request_adapter(
     let global = Arc::clone(instance.global());
     std::thread::spawn(move || {
         let adapter_id = {
-            #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+            #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
             {
                 global.request_adapter(&opts, wgt::Backends::METAL, None)
             }

--- a/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
+++ b/crates/canvas-c/src/webgpu/gpu_canvas_context.rs
@@ -542,7 +542,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize(
                 }
 
                 let ((read_back, error), texture_data) = {
-                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
                     let mut format = wgt::TextureFormat::Bgra8Unorm;
 
                     #[cfg(any(target_os = "android"))]
@@ -607,7 +607,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize(
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub unsafe extern "C" fn canvas_native_webgpu_context_create(
     instance: *const CanvasWebGPUInstance,
@@ -642,7 +642,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_create(
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub unsafe extern "C" fn canvas_native_webgpu_context_create_uiview(
     instance: *const CanvasWebGPUInstance,
@@ -684,7 +684,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_create_uiview(
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub unsafe extern "C" fn canvas_native_webgpu_context_resize_uiview(
     context: *const crate::webgpu::gpu_canvas_context::CanvasGPUCanvasContext,
@@ -741,7 +741,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize_uiview(
                 }
 
                 let ((read_back, error), texture_data) = {
-                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
                     let mut format = wgt::TextureFormat::Bgra8Unorm;
 
                     #[cfg(any(target_os = "android"))]
@@ -907,7 +907,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize_nsview(
                 }
 
                 let ((read_back, error), texture_data) = {
-                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
                     let mut format = wgt::TextureFormat::Bgra8Unorm;
 
                     #[cfg(any(target_os = "android"))]
@@ -973,7 +973,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize_nsview(
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub unsafe extern "C" fn canvas_native_webgpu_context_resize_layer(
     context: *const CanvasGPUCanvasContext,
@@ -1025,7 +1025,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_resize_layer(
                 }
 
                 let ((read_back, error), texture_data) = {
-                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+                    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
                     let mut format = TextureFormat::Bgra8Unorm;
 
                     #[cfg(any(target_os = "android"))]
@@ -1204,7 +1204,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_configure(
         vec![]
     };
 
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
     let mut format = TextureFormat::Bgra8Unorm;
 
     #[cfg(any(target_os = "android"))]
@@ -1244,7 +1244,7 @@ pub unsafe extern "C" fn canvas_native_webgpu_context_configure(
     }
 
     let ((read_back, error), texture_data) = {
-        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
         let mut format = TextureFormat::Bgra8Unorm;
 
         #[cfg(any(target_os = "android"))]

--- a/crates/canvas-c/src/webgpu/gpu_texture.rs
+++ b/crates/canvas-c/src/webgpu/gpu_texture.rs
@@ -223,10 +223,10 @@ pub extern "C" fn canvas_native_webgpu_texture_get_format(
     texture: *const CanvasGPUTexture,
 ) -> CanvasGPUTextureFormat {
     if texture.is_null() {
-        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+        #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
         return CanvasGPUTextureFormat::Bgra8Unorm;
 
-        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "visionos")))]
+        #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos")))]
         return CanvasGPUTextureFormat::Rgba8Unorm;
     }
     let texture = unsafe { &*texture };

--- a/crates/canvas-c/src/webgpu/mod.rs
+++ b/crates/canvas-c/src/webgpu/mod.rs
@@ -6,7 +6,7 @@ pub use wgt;
 #[macro_use]
 pub mod macros {
     #[macro_export]
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
     macro_rules! gfx_select {
         ($id:expr => $p0:ident.$p1:tt.$method:ident $params:tt) => {
           gfx_select!($id => {$p0.$p1}, $method $params)

--- a/crates/canvas-core/Cargo.toml
+++ b/crates/canvas-core/Cargo.toml
@@ -21,7 +21,7 @@ skia-safe = { workspace = true, optional = true }
 ash = { version = "0.38.0", optional = true, features = ["libloading"] }
 ash-window = { version = "0.13.0", optional = true }
 
-[target.'cfg(any(target_os = "ios", target_os="macos", target_os = "visionos"))'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os="macos", target_os = "visionos", target_os = "tvos"))'.dependencies]
 objc2 = { workspace = true }
 objc2-foundation = { workspace = true }
 foreign-types-shared = "0.3.1"

--- a/crates/canvas-core/src/gpu/gl/mod.rs
+++ b/crates/canvas-core/src/gpu/gl/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 mod ios;
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 pub use ios::*;
 
 #[cfg(target_os = "macos")]
@@ -40,13 +40,13 @@ pub fn get_shader_info_log(shader: u32) -> String {
 }
 
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 pub(crate) fn get_proc_address(addr: &str) -> *const std::os::raw::c_void {
     use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
     use core_foundation::string::CFString;
     use core_foundation::base::TCFType;
     let symbol_name = CFString::new(addr);
-    #[cfg(any(target_os = "ios", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
     let framework_name = CFString::new("com.apple.opengles");
 
     #[cfg(target_os = "macos")]

--- a/crates/canvas-core/src/gpu/mod.rs
+++ b/crates/canvas-core/src/gpu/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 pub mod metal;
 #[cfg(feature = "vulkan")]
 pub mod vulkan;

--- a/crates/canvas-core/src/lib.rs
+++ b/crates/canvas-core/src/lib.rs
@@ -2,6 +2,6 @@ pub mod context_attributes;
 pub mod image_asset;
 pub mod gpu;
 
-#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
 pub mod io_surface;
 pub mod cpu;

--- a/crates/canvas-ios/src/mtl.rs
+++ b/crates/canvas-ios/src/mtl.rs
@@ -161,7 +161,7 @@ pub extern "C" fn canvas_native_init_ios_webgpu_nsview(
     0
 }
 
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 #[no_mangle]
 pub extern "C" fn canvas_native_resize_ios_webgpu_uiview(
     context: i64,

--- a/crates/canvas-webgl/src/prelude.rs
+++ b/crates/canvas-webgl/src/prelude.rs
@@ -318,7 +318,7 @@ impl WebGLState {
         instance
     }
 
-    #[cfg(any(target_os = "ios", target_os = "visionos"))]
+    #[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
     pub fn snapshot(&self) -> Option<Vec<u8>> {
         self.context.snapshot()
     }

--- a/crates/canvas-webgl/src/webgl.rs
+++ b/crates/canvas-webgl/src/webgl.rs
@@ -48,7 +48,7 @@ pub fn canvas_native_webgl_bind_buffer(target: u32, buffer: u32, state: &mut Web
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "visionos")))]
+#[cfg(not(any(target_os = "ios", target_os = "visionos", target_os = "tvos")))]
 pub fn canvas_native_webgl_bind_frame_buffer(
     target: u32,
     framebuffer: u32,
@@ -60,7 +60,7 @@ pub fn canvas_native_webgl_bind_frame_buffer(
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "visionos", target_os = "tvos"))]
 pub fn canvas_native_webgl_bind_frame_buffer(
     target: u32,
     framebuffer: u32,
@@ -1079,7 +1079,7 @@ pub fn canvas_native_webgl_get_error(state: &mut WebGLState) -> u32 {
     ret
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "visionos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos")))]
 pub fn canvas_native_webgl_get_extension(
     name: &str,
     state: &mut WebGLState,
@@ -1212,7 +1212,7 @@ pub fn canvas_native_webgl_get_extension(
     extension
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos"))]
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "visionos", target_os = "tvos"))]
 pub fn canvas_native_webgl_get_extension(
     name: &str,
     state: &mut WebGLState,

--- a/crates/gl-bindings/build.rs
+++ b/crates/gl-bindings/build.rs
@@ -11,7 +11,7 @@ fn main() {
         android: { target_os = "android" },
         wasm: { target_arch = "wasm32" },
         macos: { target_os = "macos" },
-        ios: { target_os = "ios" },
+        ios: { any(target_os = "ios", target_os = "tvos") },
         // apple: { any(target_os = "ios", target_os = "macos") },
         free_unix: { all(unix, not(apple), not(android)) },
 

--- a/nativescript-v8/Package.swift
+++ b/nativescript-v8/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "CanvasNative",
-    platforms: [.iOS(.v12), .visionOS(.v1)],
+    platforms: [.iOS(.v12), .visionOS(.v1), .tvOS(.v13)],
     products: [
         .library(name: "NativeScriptV8", targets: ["NativeScriptV8"]),
     ],

--- a/packages/canvas-media/platforms/ios/src/NSCAudioView.m
+++ b/packages/canvas-media/platforms/ios/src/NSCAudioView.m
@@ -8,7 +8,9 @@
 @implementation NSCAudioView {
     __weak NSCAudioHelper *_helper;
     UIButton *_playButton;
-    UISlider *_slider;
+#if !TARGET_OS_TV
+    UISlider *_slider; // tvOS has no UISlider; seeking is done with the remote instead.
+#endif
     UILabel *_timeLabel;
     BOOL _isSeeking;
     UIImage *_customPlayImage;
@@ -40,6 +42,7 @@
         [_playButton addTarget:self action:@selector(playTapped:) forControlEvents:UIControlEventTouchUpInside];
         [self addSubview:_playButton];
 
+#if !TARGET_OS_TV
         _slider = [[UISlider alloc] initWithFrame:CGRectZero];
         _slider.translatesAutoresizingMaskIntoConstraints = YES;
         _slider.enabled = NO;
@@ -47,13 +50,16 @@
         [_slider addTarget:self action:@selector(sliderTouchDown:) forControlEvents:UIControlEventTouchDown];
         [_slider addTarget:self action:@selector(sliderTouchUp:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
         [self addSubview:_slider];
+#endif
 
         _timeLabel = [[UILabel alloc] initWithFrame:CGRectZero];
         _timeLabel.translatesAutoresizingMaskIntoConstraints = YES;
         _durationSeconds = 0.0;
         _timeLabel.text = @"0:00 / 0:00";
+#if !TARGET_OS_TV
         _slider.minimumValue = 0;
         _slider.maximumValue = 1.0f;
+#endif
         [self addSubview:_timeLabel];
     }
     return self;
@@ -79,12 +85,14 @@
     CGFloat labelY = floor((h - labelH) / 2.0);
     _timeLabel.frame = CGRectMake(labelX, labelY, labelW, labelH);
 
+#if !TARGET_OS_TV
     CGFloat sliderX = CGRectGetMaxX(_playButton.frame) + pad;
     CGFloat sliderW = labelX - pad - sliderX;
     if (sliderW < 40.0) sliderW = 40.0;
     CGFloat sliderH = 30.0;
     CGFloat sliderY = floor((h - sliderH) / 2.0);
     _slider.frame = CGRectMake(sliderX, sliderY, sliderW, sliderH);
+#endif
 }
 
 - (void)playTapped:(id)sender {
@@ -96,6 +104,7 @@
     }
 }
 
+#if !TARGET_OS_TV
 - (void)sliderChanged:(UISlider *)s {
     if (!_isSeeking) return;
     double seconds = s.value;
@@ -117,11 +126,14 @@
     double seconds = s.value;
     [_helper setCurrentTime:seconds];
 }
+#endif
 
 - (void)updateCurrentTime:(double)seconds {
     if (_isSeeking) return;
     dispatch_async(dispatch_get_main_queue(), ^{
+#if !TARGET_OS_TV
 			self->_slider.value = seconds;
+#endif
 			[self updateTimeLabelWithCurrent:seconds duration:self->_durationSeconds];
     });
 }
@@ -259,16 +271,20 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) return;
+        strongSelf->_durationSeconds = seconds;
+#if !TARGET_OS_TV
         strongSelf->_slider.minimumValue = 0;
         if (seconds > 0) {
             strongSelf->_slider.maximumValue = (float)seconds;
         } else {
             strongSelf->_slider.maximumValue = 1.0f;
         }
-        strongSelf->_durationSeconds = seconds;
         strongSelf->_slider.enabled = (!isnan(seconds) && seconds > 0);
         if (strongSelf->_slider.value > strongSelf->_slider.maximumValue) strongSelf->_slider.value = strongSelf->_slider.maximumValue;
         [strongSelf updateTimeLabelWithCurrent:strongSelf->_slider.value duration:strongSelf->_durationSeconds];
+#else
+        [strongSelf updateTimeLabelWithCurrent:0 duration:strongSelf->_durationSeconds];
+#endif
     });
 }
 

--- a/packages/canvas-media/platforms/ios/src/NSCVideoHelper.m
+++ b/packages/canvas-media/platforms/ios/src/NSCVideoHelper.m
@@ -280,11 +280,18 @@ static NSArray<AVAssetTrack *> *NSCTracksWithMediaType(AVAsset *asset, AVMediaTy
 }
 
 - (BOOL)playsinline {
+#if TARGET_OS_TV
+    // tvOS AVPlayerViewController is always full screen; there is no inline mode to toggle.
+    return NO;
+#else
     return !self.controller.entersFullScreenWhenPlaybackBegins;
+#endif
 }
 
 - (void)setPlaysinline:(BOOL)playsinline {
+#if !TARGET_OS_TV
     self.controller.entersFullScreenWhenPlaybackBegins = !playsinline;
+#endif
 }
 
 - (void)play {

--- a/packages/canvas-polyfill/async/http/http.ios.ts
+++ b/packages/canvas-polyfill/async/http/http.ios.ts
@@ -1,5 +1,6 @@
-import { File, knownFolders, path, ApplicationSettings, Utils } from '@nativescript/core';
+import { File, path, ApplicationSettings, Utils } from '@nativescript/core';
 import { FileManager } from '../file/file';
+import { storageFolderPath } from '../../storage-folder';
 import { fileNameFromPath, Headers, HttpDownloadRequestOptions, HttpError, HttpRequestOptions, isImageUrl, SaveImageStorageKey, TNSHttpSettings } from './http-request-common';
 
 export type CancellablePromise = Promise<any> & { cancel: () => void };
@@ -723,7 +724,7 @@ export class Http {
 							// strip any params if were any
 							filename = filename.split('?')[0];
 						}
-						localPath = path.join(knownFolders.documents().path, filename);
+						localPath = path.join(storageFolderPath(), filename);
 						makeRemoteRequest();
 					}
 

--- a/packages/canvas-polyfill/localStorage.ts
+++ b/packages/canvas-polyfill/localStorage.ts
@@ -1,4 +1,5 @@
-import { File, knownFolders } from '@nativescript/core';
+import { File } from '@nativescript/core';
+import { storageFolderPath } from './storage-folder';
 
 let file: File;
 let localStorageTimeout = null;
@@ -116,7 +117,7 @@ if (!global.Storage) {
 }
 
 if (!global.localStorage || (typeof module !== 'undefined' && (<any>module)?.hot)) {
-	const path = knownFolders.documents().path + '/localStorage.db';
+	const path = storageFolderPath() + '/localStorage.db';
 	file = File.fromPath(path);
 	localStorageTimeout = null;
 

--- a/packages/canvas-polyfill/storage-folder.ts
+++ b/packages/canvas-polyfill/storage-folder.ts
@@ -1,0 +1,12 @@
+import { knownFolders } from '@nativescript/core';
+
+/**
+ * Where the polyfill keeps its files (localStorage.db, materialised Blobs, downloaded images).
+ * tvOS apps have no writable Documents directory (only Library/Caches and tmp); on a physical Apple TV
+ * creating a file under Documents aborts the app, while the simulator tolerates it. Caches may be purged
+ * by the system under storage pressure, which is the documented tvOS persistence model.
+ */
+export function storageFolderPath(): string {
+	const isTvOS = typeof (global as any).__TVOS__ !== 'undefined' ? !!(global as any).__TVOS__ : typeof UIDevice !== 'undefined' && UIDevice.currentDevice.userInterfaceIdiom === UIUserInterfaceIdiom.TV;
+	return isTvOS ? knownFolders.ios.library().getFolder('Caches').path : knownFolders.documents().path;
+}

--- a/packages/canvas-polyfill/urlBlobPatch.ts
+++ b/packages/canvas-polyfill/urlBlobPatch.ts
@@ -1,4 +1,5 @@
-import { Folder, knownFolders, path, Utils, File as NSFile } from '@nativescript/core';
+import { Folder, path, Utils, File as NSFile } from '@nativescript/core';
+import { storageFolderPath } from './storage-folder';
 
 const BLOB_PATH = 'blob:nativescript/';
 const BLOB_DIR = 'ns_blobs';
@@ -90,9 +91,9 @@ if (typeof URL !== 'undefined') {
 			const createObjectURLLegacyWithId = (id: string, object: any, options = null) => {
 				const buf = (Blob as any).InternalAccessor.getBuffer(object);
 				if (buf || object instanceof Blob || object instanceof File) {
-					const exists = Folder.exists(path.join(knownFolders.documents().path, BLOB_DIR));
+					const exists = Folder.exists(path.join(storageFolderPath(), BLOB_DIR));
 					if (!exists) {
-						Folder.fromPath(path.join(knownFolders.documents().path, BLOB_DIR));
+						Folder.fromPath(path.join(storageFolderPath(), BLOB_DIR));
 					}
 					let fileName = id;
 					// todo get type from magic bytes
@@ -100,7 +101,7 @@ if (typeof URL !== 'undefined') {
 						fileName = `${fileName}.${options.ext}`;
 					}
 
-					const filePath = path.join(knownFolders.documents().path, BLOB_DIR, fileName);
+					const filePath = path.join(storageFolderPath(), BLOB_DIR, fileName);
 
 					NSFile.fromPath(filePath).writeSync(NSData.dataWithData(buf));
 
@@ -111,7 +112,7 @@ if (typeof URL !== 'undefined') {
 			};
 
 			const getItem = (key: string) => {
-				const fileDir = Folder.fromPath(path.join(knownFolders.documents().path, BLOB_DIR));
+				const fileDir = Folder.fromPath(path.join(storageFolderPath(), BLOB_DIR));
 				let fileName = null;
 
 				if (!sharedPreferences) {
@@ -161,7 +162,7 @@ if (typeof URL !== 'undefined') {
 					fileName = `${fileName}.${blob?.ext}`;
 				}
 
-				const filePath = path.join(knownFolders.documents().path, BLOB_DIR, fileName);
+				const filePath = path.join(storageFolderPath(), BLOB_DIR, fileName);
 
 				blob.path = filePath;
 
@@ -201,9 +202,9 @@ if (__APPLE__) {
 	const createObjectURLLegacyWithId = (id: string, object: any, options = null) => {
 		const buf = (Blob as any).InternalAccessor.getBuffer(object);
 		if (buf || object instanceof Blob || object instanceof File) {
-			const exists = Folder.exists(path.join(knownFolders.documents().path, BLOB_DIR));
+			const exists = Folder.exists(path.join(storageFolderPath(), BLOB_DIR));
 			if (!exists) {
-				Folder.fromPath(path.join(knownFolders.documents().path, BLOB_DIR));
+				Folder.fromPath(path.join(storageFolderPath(), BLOB_DIR));
 			}
 			let fileName = id;
 			// todo get type from magic bytes
@@ -211,7 +212,7 @@ if (__APPLE__) {
 				fileName = `${fileName}.${options.ext}`;
 			}
 
-			const filePath = path.join(knownFolders.documents().path, BLOB_DIR, fileName);
+			const filePath = path.join(storageFolderPath(), BLOB_DIR, fileName);
 
 			NSFile.fromPath(filePath).writeSync(NSData.dataWithData(buf));
 
@@ -222,7 +223,7 @@ if (__APPLE__) {
 	};
 
 	const getItem = (key: string) => {
-		const fileDir = Folder.fromPath(path.join(knownFolders.documents().path, BLOB_DIR));
+		const fileDir = Folder.fromPath(path.join(storageFolderPath(), BLOB_DIR));
 		let fileName = null;
 
 		if (!sharedPreferences) {
@@ -272,7 +273,7 @@ if (__APPLE__) {
 			fileName = `${fileName}.${blob?.ext}`;
 		}
 
-		const filePath = path.join(knownFolders.documents().path, BLOB_DIR, fileName);
+		const filePath = path.join(storageFolderPath(), BLOB_DIR, fileName);
 
 		blob.path = filePath;
 

--- a/packages/canvas-svg/platforms/ios/build.xcconfig
+++ b/packages/canvas-svg/platforms/ios/build.xcconfig
@@ -1,4 +1,6 @@
 OTHER_LDFLAGS[sdk=iphone*] = $(inherited) -framework Foundation -framework CanvasSVG -framework OpenGLES -framework GLKit
 OTHER_LDFLAGS[sdk=xros*] = $(inherited) -framework Foundation -framework CanvasSVG
 OTHER_LDFLAGS[sdk=xrsimulator*] = $(inherited) -framework Foundation -framework CanvasSVG
+OTHER_LDFLAGS[sdk=appletvos*] = $(inherited) -framework Foundation -framework CanvasSVG
+OTHER_LDFLAGS[sdk=appletvsimulator*] = $(inherited) -framework Foundation -framework CanvasSVG
 OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Foundation -framework CanvasSVG

--- a/packages/canvas-svg/src-native/ios/CanvasSVG.xcodeproj/project.pbxproj
+++ b/packages/canvas-svg/src-native/ios/CanvasSVG.xcodeproj/project.pbxproj
@@ -470,18 +470,35 @@
 					"-ObjC",
 					"-lc++",
 				);
+				"OTHER_LDFLAGS[sdk=appletvos*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos/debug\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvassvg",
+					"-ObjC",
+					"-lc++",
+				);
+				"OTHER_LDFLAGS[sdk=appletvsimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos-sim/debug\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvassvg",
+					"-ObjC",
+					"-lc++",
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -Wno-error=non-modular-include-in-framework-module";
 				PRODUCT_BUNDLE_IDENTIFIER = org.nativescript.canvas.svg.CanvasSVG;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator appletvos appletvsimulator";
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Debug;
 		};
@@ -565,17 +582,34 @@
 					"-ObjC",
 					"-lc++",
 				);
+				"OTHER_LDFLAGS[sdk=appletvos*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos/release\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvassvg",
+					"-ObjC",
+					"-lc++",
+				);
+				"OTHER_LDFLAGS[sdk=appletvsimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos-sim/release\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvassvg",
+					"-ObjC",
+					"-lc++",
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -Wno-error=non-modular-include-in-framework-module";
 				PRODUCT_BUNDLE_IDENTIFIER = org.nativescript.canvas.svg.CanvasSVG;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator appletvos appletvsimulator";
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Release;
 		};
@@ -596,7 +630,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Debug;
 		};
@@ -617,7 +651,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Release;
 		};

--- a/packages/canvas-svg/src-native/ios/build.sh
+++ b/packages/canvas-svg/src-native/ios/build.sh
@@ -62,6 +62,38 @@ xcodebuild \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
+echo "Build for appletvsimulator (tvOS Simulator)"
+xcodebuild \
+    -project CanvasSVG.xcodeproj \
+    -scheme CanvasSVG \
+    -sdk appletvsimulator \
+    -destination "generic/platform=tvOS Simulator" \
+    -configuration Release \
+    -quiet \
+    clean build \
+    BUILD_DIR=$(PWD)/dist \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+echo "Build for appletvos (tvOS)"
+xcodebuild \
+    -project CanvasSVG.xcodeproj \
+    -scheme CanvasSVG \
+    -sdk appletvos \
+    -destination "generic/platform=tvOS" \
+    -configuration Release \
+    -quiet \
+    clean build \
+    BUILD_DIR=$(PWD)/dist \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
 echo "Creating XCFramework"
 xcodebuild \
     -create-xcframework \
@@ -73,6 +105,10 @@ xcodebuild \
     -debug-symbols $(PWD)/dist/Release-xros/CanvasSVG.framework.dSYM \
     -framework $(PWD)/dist/Release-xrsimulator/CanvasSVG.framework \
     -debug-symbols $(PWD)/dist/Release-xrsimulator/CanvasSVG.framework.dSYM \
+    -framework $(PWD)/dist/Release-appletvos/CanvasSVG.framework \
+    -debug-symbols $(PWD)/dist/Release-appletvos/CanvasSVG.framework.dSYM \
+    -framework $(PWD)/dist/Release-appletvsimulator/CanvasSVG.framework \
+    -debug-symbols $(PWD)/dist/Release-appletvsimulator/CanvasSVG.framework.dSYM \
     -output $(PWD)/dist/CanvasSVG.xcframework
 
 echo "Publishing XCFramework to packages/canvas-svg/platforms/ios"

--- a/packages/canvas-svg/src-native/ios/pre-build.sh
+++ b/packages/canvas-svg/src-native/ios/pre-build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-source $HOME/.cargo/env
-source $HOME/.profile
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+[ -f "$HOME/.profile" ] && source "$HOME/.profile"
 
 whereis cc
 
@@ -57,6 +57,12 @@ if [[ "$PLATFORM_NAME" == xr* ]]; then
   IS_VISIONOS=true
 fi
 
+# tvOS reports PLATFORM_NAME as "appletvos" (device) / "appletvsimulator" (simulator).
+IS_TVOS=false
+if [[ "$PLATFORM_NAME" == appletv* ]]; then
+  IS_TVOS=true
+fi
+
 if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
     # it's better to rely on platform name as fallback because architecture differs between simulator and device
@@ -76,6 +82,12 @@ if $IS_VISIONOS; then
     RUST_BUILD_TARGET="aarch64-apple-visionos-sim"
   else
     RUST_BUILD_TARGET="aarch64-apple-visionos"
+  fi
+elif $IS_TVOS; then
+  if [[ $IS_SIMULATOR == true ]] || [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
+    RUST_BUILD_TARGET="aarch64-apple-tvos-sim"
+  else
+    RUST_BUILD_TARGET="aarch64-apple-tvos"
   fi
 else
   if [[ $CURRENT_ARCH == x86_64 ]]; then

--- a/packages/canvas/Canvas/common.ts
+++ b/packages/canvas/Canvas/common.ts
@@ -323,6 +323,29 @@ export class WheelEvent extends UIEvent {
 	}
 }
 
+interface KeyboardEventOptions extends UIEventOptions {
+	key?: string;
+	code?: string;
+	repeat?: boolean;
+}
+
+/**
+ * Minimal DOM KeyboardEvent. Fed by physical/remote keys on platforms that have them
+ * (tvOS: Siri Remote select/menu/play-pause and the directional presses map to DOM key names).
+ */
+export class KeyboardEvent extends UIEvent {
+	readonly key: string;
+	readonly code: string;
+	readonly repeat: boolean;
+
+	constructor(type: 'keydown' | 'keyup', options?: KeyboardEventOptions) {
+		super(type as any, options);
+		this.key = options?.key ?? '';
+		this.code = options?.code ?? '';
+		this.repeat = options?.repeat ?? false;
+	}
+}
+
 class Rectangle {
 	top: number;
 	left: number;
@@ -469,6 +492,8 @@ export abstract class CanvasBase extends ContainerView implements ICanvasBase {
 	_mouseDownCallbacks = [];
 	_mouseCancelCallbacks = [];
 	_mouseWheelCallbacks = [];
+	_keyDownCallbacks = [];
+	_keyUpCallbacks = [];
 
 	_touchStartCallbacks = new Array<(arg0: TouchEvent) => void>();
 	_touchEndCallbacks = new Array<(arg0: TouchEvent) => void>();
@@ -600,6 +625,12 @@ export abstract class CanvasBase extends ContainerView implements ICanvasBase {
 			case 'dommousescroll':
 				this._mouseWheelCallbacks.push(callback);
 				break;
+			case 'keydown':
+				this._keyDownCallbacks.push(callback);
+				break;
+			case 'keyup':
+				this._keyUpCallbacks.push(callback);
+				break;
 		}
 	}
 
@@ -669,6 +700,12 @@ export abstract class CanvasBase extends ContainerView implements ICanvasBase {
 			case 'mousewheel':
 			case 'dommousescroll':
 				removeItemFromArray(this._mouseWheelCallbacks, callback);
+				break;
+			case 'keydown':
+				removeItemFromArray(this._keyDownCallbacks, callback);
+				break;
+			case 'keyup':
+				removeItemFromArray(this._keyUpCallbacks, callback);
 				break;
 		}
 	}
@@ -1071,6 +1108,23 @@ export abstract class CanvasBase extends ContainerView implements ICanvasBase {
 		}
 	}
 
+	private _keyCallback(data: { phase: string; key: string; code: string; repeat?: boolean }) {
+		const callbacks = data.phase === 'up' ? this._keyUpCallbacks : this._keyDownCallbacks;
+		if (callbacks.length === 0) {
+			return;
+		}
+		const event = new KeyboardEvent(data.phase === 'up' ? 'keyup' : 'keydown', {
+			key: data.key,
+			code: data.code,
+			repeat: !!data.repeat,
+			target: this.__target ?? this,
+			cancelable: true,
+		} as any);
+		for (const callback of callbacks.slice()) {
+			callback(event);
+		}
+	}
+
 	private _pinchCallback(data: { event: string; deltaX: number; deltaY: number; deltaMode: number; pointers: { ptrId: number; x: number; y: number }[]; isInProgress: boolean }) {
 		// move callback
 
@@ -1208,6 +1262,9 @@ export abstract class CanvasBase extends ContainerView implements ICanvasBase {
 					break;
 				case 'scale':
 					this._pinchCallback(data);
+					break;
+				case 'key':
+					this._keyCallback(data);
 					break;
 				case 'cancel':
 					this._cancelCallback(data.ptrId, data.x, data.y, data.isPrimary);

--- a/packages/canvas/platforms/ios/build.xcconfig
+++ b/packages/canvas/platforms/ios/build.xcconfig
@@ -1,6 +1,8 @@
 OTHER_LDFLAGS[sdk=iphone*] = $(inherited) -framework Foundation -framework CanvasNative -framework OpenGLES -framework GLKit
 OTHER_LDFLAGS[sdk=xros*] = $(inherited) -framework Foundation -framework CanvasNative -framework Metal
 OTHER_LDFLAGS[sdk=xrsimulator*] = $(inherited) -framework Foundation -framework CanvasNative -framework Metal
+OTHER_LDFLAGS[sdk=appletvos*] = $(inherited) -framework Foundation -framework CanvasNative -framework OpenGLES -framework GLKit -framework Metal
+OTHER_LDFLAGS[sdk=appletvsimulator*] = $(inherited) -framework Foundation -framework CanvasNative -framework OpenGLES -framework GLKit -framework Metal
 OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Foundation -framework CanvasNative -framework Metal
 
 CLANG_CXX_LANGUAGE_STANDARD = c++17

--- a/packages/canvas/src-native/canvas-ios/CanvasNative.xcodeproj/project.pbxproj
+++ b/packages/canvas/src-native/canvas-ios/CanvasNative.xcodeproj/project.pbxproj
@@ -613,6 +613,30 @@
 					"-framework",
 					Metal,
 				);
+				"OTHER_LDFLAGS[sdk=appletvos*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos/debug\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvasnative",
+					"-lc++",
+					"-ObjC",
+					"-framework",
+					OpenGLES,
+					"-framework",
+					Metal,
+				);
+				"OTHER_LDFLAGS[sdk=appletvsimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos-sim/debug\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvasnative",
+					"-lc++",
+					"-ObjC",
+					"-framework",
+					OpenGLES,
+					"-framework",
+					Metal,
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -Wno-error=non-modular-include-in-framework-module";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.triniwiz.CanvasNative;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -621,15 +645,18 @@
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_SWIFT_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator appletvos appletvsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				USE_HEADERMAP = NO;
 				XROS_DEPLOYMENT_TARGET = 1.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*]" = "NSCCanvas.xib";
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator*]" = "NSCCanvas.xib";
 			};
 			name = Debug;
 		};
@@ -717,6 +744,30 @@
 					"-framework",
 					Metal,
 				);
+				"OTHER_LDFLAGS[sdk=appletvos*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos/release\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvasnative",
+					"-lc++",
+					"-ObjC",
+					"-framework",
+					OpenGLES,
+					"-framework",
+					Metal,
+				);
+				"OTHER_LDFLAGS[sdk=appletvsimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"-L\"$(SRCROOT)/../../../../target/aarch64-apple-tvos-sim/release\"",
+					"-Wl,-no_compact_unwind",
+					"-lcanvasnative",
+					"-lc++",
+					"-ObjC",
+					"-framework",
+					OpenGLES,
+					"-framework",
+					Metal,
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -Wno-error=non-modular-include-in-framework-module";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.triniwiz.CanvasNative;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -725,14 +776,17 @@
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_SWIFT_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator appletvos appletvsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				USE_HEADERMAP = NO;
 				XROS_DEPLOYMENT_TARGET = 1.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*]" = "NSCCanvas.xib";
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator*]" = "NSCCanvas.xib";
 			};
 			name = Release;
 		};
@@ -750,7 +804,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.triniwiz.CanvasNativeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Debug;
 		};
@@ -768,7 +822,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.triniwiz.CanvasNativeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Release;
 		};

--- a/packages/canvas/src-native/canvas-ios/CanvasNative/Source/NSCCanvas.swift
+++ b/packages/canvas/src-native/canvas-ios/CanvasNative/Source/NSCCanvas.swift
@@ -10,7 +10,9 @@ import UIKit
 #if !os(visionOS)
 import GLKit
 #endif
+#if canImport(WebKit)
 import WebKit
+#endif
 import MetalKit
 
 // visionOS has no `UIScreen` (no single main screen). Views render at a 2x scale and the
@@ -28,7 +30,7 @@ import MetalKit
 #else
 @inline(__always) func nscNativeScale() -> CGFloat { UIScreen.main.nativeScale }
 @inline(__always) func nscIsWideGamut() -> Bool {
-	if #available(iOS 11.0, *) { return UIScreen.main.traitCollection.displayGamut == .P3 }
+	if #available(iOS 11.0, tvOS 11.0, *) { return UIScreen.main.traitCollection.displayGamut == .P3 }
 	return false
 }
 #endif
@@ -249,7 +251,7 @@ public class NSCCanvas: UIView {
 					return "data:,"
 				}
 			case "image/heic", "image/heic-sequence":
-				if #available(iOS 17.0, *), let data = image.heicData() {
+				if #available(iOS 17.0, tvOS 17.0, *), let data = image.heicData() {
 					base64ImageString = data.base64EncodedString()
 				} else {
 					return "data:,"
@@ -457,7 +459,7 @@ public class NSCCanvas: UIView {
 			mtlView.isOpaque = !alpha
 			
 			if(cs == 1){
-				if #available(iOS 13.0, *) {
+				if #available(iOS 13.0, tvOS 13.0, *) {
 					(mtlView.layer as! CAMetalLayer).colorspace = CGColorSpace(name: CGColorSpace.displayP3)
 				}
 			}
@@ -573,6 +575,71 @@ public class NSCCanvas: UIView {
 	private var handler: NSCTouchHandler?
 	
 	public var touchEventListener: ((String, UIGestureRecognizer) -> Void)?
+
+	// MARK: - Remote / keyboard presses
+	//
+	// On tvOS the Siri Remote and game controllers deliver UIPress events instead of touches.
+	// They are forwarded through the same listener as touch events, as a `key` event carrying DOM
+	// key names (ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Enter, Escape, MediaPlayPause) so the JS
+	// side can dispatch KeyboardEvents. tvOS only: on iOS the canvas keeps its default responder
+	// behaviour and does not intercept UIPress events.
+	#if os(tvOS)
+	public override var canBecomeFirstResponder: Bool { true }
+
+	// tvOS routes remote presses through the focus engine: the canvas must be focusable to receive
+	// them when it is the only content on screen.
+	public override var canBecomeFocused: Bool { true }
+
+	public override func didMoveToWindow() {
+		super.didMoveToWindow()
+		if window != nil {
+			becomeFirstResponder()
+			setNeedsFocusUpdate()
+		}
+	}
+
+	private static func domKey(for type: UIPress.PressType) -> (key: String, code: String)? {
+		switch type {
+		case .upArrow: return ("ArrowUp", "ArrowUp")
+		case .downArrow: return ("ArrowDown", "ArrowDown")
+		case .leftArrow: return ("ArrowLeft", "ArrowLeft")
+		case .rightArrow: return ("ArrowRight", "ArrowRight")
+		case .select: return ("Enter", "Enter")
+		case .menu: return ("Escape", "Escape")
+		case .playPause: return ("MediaPlayPause", "MediaPlayPause")
+		@unknown default: return nil
+		}
+	}
+
+	private func forwardPresses(_ presses: Set<UIPress>, phase: String) -> Bool {
+		guard let listener = touchEventListener else { return false }
+		var handled = false
+		for press in presses {
+			guard let mapped = NSCCanvas.domKey(for: press.type) else { continue }
+			let json = "{\"event\":\"key\",\"phase\":\"\(phase)\",\"key\":\"\(mapped.key)\",\"code\":\"\(mapped.code)\"}"
+			listener(json, handler?.gestureRecognizer ?? UIGestureRecognizer())
+			handled = true
+		}
+		return handled
+	}
+
+	// The presses are forwarded and then passed up the responder chain, so system behaviour
+	// (Menu returning to the home screen, focus navigation) is preserved.
+	public override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+		_ = forwardPresses(presses, phase: "down")
+		super.pressesBegan(presses, with: event)
+	}
+
+	public override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+		_ = forwardPresses(presses, phase: "up")
+		super.pressesEnded(presses, with: event)
+	}
+
+	public override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+		_ = forwardPresses(presses, phase: "up")
+		super.pressesCancelled(presses, with: event)
+	}
+	#endif
 	
 	required init?(coder: NSCoder) {
 		let scale = nscNativeScale()

--- a/packages/canvas/src-native/canvas-ios/NSCTouchHandler.swift
+++ b/packages/canvas/src-native/canvas-ios/NSCTouchHandler.swift
@@ -12,7 +12,9 @@ class NSCTouchHandler: NSObject {
     private let view: NSCCanvas
     var gestureRecognizer: TouchGestureRecognizer?
     var panRecognizer: UIPanGestureRecognizer?
+    #if !os(tvOS)
     var pinchRecognizer: UIPinchGestureRecognizer?
+    #endif
     
     
     var pointers: [Pointer] = []
@@ -40,7 +42,10 @@ class NSCTouchHandler: NSObject {
         self.gestureRecognizer = TouchGestureRecognizer(target: self, action: nil)
         self.gestureRecognizer?.handler = self
         self.panRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handle))
+        #if !os(tvOS)
+        // tvOS has no UIPinchGestureRecognizer (Siri Remote touch surface is single-touch).
         self.pinchRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handle))
+        #endif
         self.pointers.reserveCapacity(10)
     }
     

--- a/packages/canvas/src-native/canvas-ios/build.sh
+++ b/packages/canvas/src-native/canvas-ios/build.sh
@@ -67,6 +67,38 @@ xcodebuild \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
+echo "Build for appletvsimulator (tvOS Simulator)"
+xcodebuild \
+    -project CanvasNative.xcodeproj \
+    -scheme CanvasNative \
+    -sdk appletvsimulator \
+    -destination "generic/platform=tvOS Simulator" \
+    -configuration Release \
+    -quiet \
+    clean build \
+    BUILD_DIR=$(PWD)/dist \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+echo "Build for appletvos (tvOS)"
+xcodebuild \
+    -project CanvasNative.xcodeproj \
+    -scheme CanvasNative \
+    -sdk appletvos \
+    -destination "generic/platform=tvOS" \
+    -configuration Release \
+    -quiet \
+    clean build \
+    BUILD_DIR=$(PWD)/dist \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
 echo "Creating XCFramework"
 xcodebuild \
     -create-xcframework \
@@ -78,4 +110,8 @@ xcodebuild \
     -debug-symbols $(PWD)/dist/Release-xros/CanvasNative.framework.dSYM \
     -framework $(PWD)/dist/Release-xrsimulator/CanvasNative.framework \
     -debug-symbols $(PWD)/dist/Release-xrsimulator/CanvasNative.framework.dSYM \
+    -framework $(PWD)/dist/Release-appletvos/CanvasNative.framework \
+    -debug-symbols $(PWD)/dist/Release-appletvos/CanvasNative.framework.dSYM \
+    -framework $(PWD)/dist/Release-appletvsimulator/CanvasNative.framework \
+    -debug-symbols $(PWD)/dist/Release-appletvsimulator/CanvasNative.framework.dSYM \
     -output $(PWD)/dist/CanvasNative.xcframework

--- a/packages/canvas/src-native/canvas-ios/pre-build.sh
+++ b/packages/canvas/src-native/canvas-ios/pre-build.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-source $HOME/.cargo/env
-source $HOME/.profile
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+[ -f "$HOME/.profile" ] && source "$HOME/.profile"
+export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:$PATH"
 
 whereis cc
 
@@ -57,6 +58,12 @@ if [[ "$PLATFORM_NAME" == xr* ]]; then
   IS_VISIONOS=true
 fi
 
+# tvOS reports PLATFORM_NAME as "appletvos" (device) / "appletvsimulator" (simulator).
+IS_TVOS=false
+if [[ "$PLATFORM_NAME" == appletv* ]]; then
+  IS_TVOS=true
+fi
+
 if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
     # it's better to rely on platform name as fallback because architecture differs between simulator and device
@@ -76,6 +83,13 @@ if $IS_VISIONOS; then
     RUST_BUILD_TARGET="aarch64-apple-visionos-sim"
   else
     RUST_BUILD_TARGET="aarch64-apple-visionos"
+  fi
+elif $IS_TVOS; then
+  # tvOS POC: arm64 device + arm64 simulator only (x86_64-apple-tvos exists in rustc but is not built here).
+  if [[ $IS_SIMULATOR == true ]] || [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
+    RUST_BUILD_TARGET="aarch64-apple-tvos-sim"
+  else
+    RUST_BUILD_TARGET="aarch64-apple-tvos"
   fi
 else
   if [[ $CURRENT_ARCH == x86_64 ]]; then
@@ -104,11 +118,11 @@ cbindgen --config "$CWD/canvas-ios/cbindgen.toml"  "$CWD/canvas-ios/src/lib.rs" 
 
 if $IS_RELEASE; then
   export RUSTFLAGS="-Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort"
-  cargo +nightly build -Z build-std='std,panic_abort' --manifest-path Cargo.toml --target $RUST_BUILD_TARGET $RUST_BUILD_TYPE -p canvas-ios
+  cargo +"${CANVAS_RUST_TOOLCHAIN:-nightly}" build -Z build-std='std,panic_abort' --manifest-path Cargo.toml --target $RUST_BUILD_TARGET $RUST_BUILD_TYPE -p canvas-ios
 
-elif $IS_VISIONOS; then
-  # visionOS is tier-3: build-std (nightly + rust-src) is required even for debug.
-  cargo +nightly build -Z build-std='std,panic_abort' --manifest-path Cargo.toml --target $RUST_BUILD_TARGET $RUST_BUILD_TYPE -p canvas-ios
+elif $IS_VISIONOS || $IS_TVOS; then
+  # visionOS/tvOS are tier-3: build-std (nightly + rust-src) is required even for debug.
+  cargo +"${CANVAS_RUST_TOOLCHAIN:-nightly}" build -Z build-std='std,panic_abort' --manifest-path Cargo.toml --target $RUST_BUILD_TARGET $RUST_BUILD_TYPE -p canvas-ios
 
 else
   cargo build --manifest-path Cargo.toml --target $RUST_BUILD_TARGET $RUST_BUILD_TYPE -p canvas-ios


### PR DESCRIPTION
Add native tvOS targets, Rust platform gates, Siri Remote forwarding, tvOS storage/media guards, and CanvasSVG configuration. Keep OpenGL ES enabled on tvOS and exclude the private Cargo path override.

## Validation

Both arm64 tvOS CanvasNative slices built from source. The pinned integration app passes platform, Canvas 2D, WebGL and WebGPU checks on the simulator. Current V8 requires #147; compute-only mapping also needs #148. The reviewer setup supplies the pinned rust-skia override until that dependency lands.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `1dffcabf119046d7bea2c402150be24f0982ff1a`, changing 41 files against `1fd6ef470dfdfd43b3385fa7ef43feddd1debd06`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
