### PR TITLE
fix(webgpu): expose GPUQuerySet.destroy

### DIFF
--- a/packages/canvas/WebGPU/GPUQuerySet.ts
+++ b/packages/canvas/WebGPU/GPUQuerySet.ts
@@ -7,6 +7,10 @@ export class GPUQuerySet {
 		return this[native_]?.label ?? '';
 	}
 
+	destroy() {
+		this[native_]?.destroy?.();
+	}
+
 	static fromNative(query) {
 		if (query) {
 			const ret = new GPUQuerySet();


### PR DESCRIPTION
Expose GPUQuerySet.destroy() through the TypeScript wrapper so callers can release the native query resource.

## Validation

The focused wrapper test passed, and the final tvOS simulator integration test creates and destroys a real query set. Independent of tvOS.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `cfe0b9de68ee97c3b51cc59cd530f9c2455af664`, changing 1 files against `1fd6ef470dfdfd43b3385fa7ef43feddd1debd06`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
