### PR TITLE
perf(tvos): defer Metal drawable acquisition until drawing

### DIFF
--- a/crates/canvas-2d/src/context/mod.rs
+++ b/crates/canvas-2d/src/context/mod.rs
@@ -341,11 +341,23 @@ impl Context {
         self.surface_data.scale
     }
 
+    // Acquiring the next drawable during presentation can block the display-link
+    // callback on tvOS. Keep the previous surface until the next operation needs
+    // to draw, then retain its contents when swapping the backing texture.
+    #[inline]
+    fn ensure_metal_drawable(&mut self) {
+        #[cfg(all(feature = "metal", target_os = "tvos"))]
+        if self.metal_context.as_ref().is_some_and(|c| !c.has_current_drawable()) {
+            Self::acquire_drawable(self);
+        }
+    }
+
     #[inline]
     pub fn with_canvas<F>(&mut self, f: F)
     where
         F: FnOnce(&skia_safe::Canvas),
     {
+        self.ensure_metal_drawable();
         f(self.surface.canvas());
     }
 
@@ -354,6 +366,7 @@ impl Context {
     where
         F: FnOnce(&skia_safe::Canvas, &mut Path),
     {
+        self.ensure_metal_drawable();
         f(self.surface.canvas(), &mut self.path);
         self.surface_state = self.surface_state | SurfaceState::Pending;
     }
@@ -363,6 +376,7 @@ impl Context {
     where
         F: FnOnce(&skia_safe::Canvas),
     {
+        self.ensure_metal_drawable();
         f(self.surface.canvas());
         self.surface_state = self.surface_state | SurfaceState::Pending;
     }
@@ -372,6 +386,7 @@ impl Context {
     where
         F: FnOnce(&skia_safe::Canvas, &Paint),
     {
+        self.ensure_metal_drawable();
         f(self.surface.canvas(), &self.state.paint);
         self.surface_state = self.surface_state | SurfaceState::Pending;
     }
@@ -388,6 +403,7 @@ impl Context {
     where
         F: FnOnce(&skia_safe::Canvas),
     {
+        self.ensure_metal_drawable();
         f(self.surface.canvas());
         self.surface_state = self.surface_state | SurfaceState::Pending;
     }
@@ -545,6 +561,7 @@ impl Context {
     where
         F: Fn(&skia_safe::Canvas, &skia_safe::Paint, &mut Path),
     {
+        self.ensure_metal_drawable();
         let blend = self.state.global_composite_operation.get_blend_mode();
         // Fast path: most draw calls use SrcOver (the default)
         if !matches!(
@@ -606,6 +623,7 @@ impl Context {
     where
         F: Fn(&skia_safe::Canvas, &skia_safe::Paint),
     {
+        self.ensure_metal_drawable();
         let blend = self.state.global_composite_operation.get_blend_mode();
         // Fast path: most draw calls use SrcOver (the default)
         if !matches!(
@@ -663,6 +681,7 @@ impl Context {
     where
         F: Fn(&skia_safe::Canvas, &skia_safe::Paint, &Font),
     {
+        self.ensure_metal_drawable();
         let blend = self.state.global_composite_operation.get_blend_mode();
         if !matches!(
             blend,

--- a/crates/canvas-2d/src/context/surface_metal.rs
+++ b/crates/canvas-2d/src/context/surface_metal.rs
@@ -349,13 +349,21 @@ impl Context {
 
     pub fn present(context: &mut Context) {
         let _ = MetalContext::new_release_pool();
-        let mut info: Option<TextureInfo> = None;
-        let mut width = 0;
-        let mut height = 0;
+
         if let Some(context) = context.metal_context.as_mut() {
             context.present_drawable();
         }
 
+        #[cfg(not(target_os = "tvos"))]
+        Self::acquire_drawable(context);
+    }
+
+    pub(crate) fn acquire_drawable(context: &mut Context) {
+        #[cfg(target_os = "tvos")]
+        let _pool = MetalContext::new_release_pool();
+        let mut info: Option<TextureInfo> = None;
+        let mut width = 0;
+        let mut height = 0;
         if let Some(context) = context.metal_context.as_mut() {
             if let Some(drawable) = context.next_drawable() {
                 let texture = drawable.texture();

--- a/crates/canvas-core/src/gpu/metal.rs
+++ b/crates/canvas-core/src/gpu/metal.rs
@@ -276,6 +276,8 @@ impl MetalContext {
         }
     }
 
+    pub fn has_current_drawable(&self) -> bool { self.current_drawable.is_some() }
+
     pub fn current_drawable(&mut self) -> Option<&Retained<ProtocolObject<dyn CAMetalDrawable>>> {
         if self.current_drawable.is_none() {
             self.current_drawable = unsafe {


### PR DESCRIPTION
Align Metal presentation with display-link frame boundaries and preserve the existing iOS presentation path.

## Validation

The full Nova Relay game was rebuilt on NativeScript 9.1 / V8 14.9 and tested on a physical Apple TV 4K with an A12 GPU. The signed Release build completed an eight-wave, four-pilot mission at 59.94 FPS (p95 16.717 ms; max 28.197 ms; 11,806 samples), then 65 seconds of 4× spawn stress at 59.94 FPS (p95 16.701 ms; max 19.331 ms; 3,717 samples). Three.js, PixiJS, bloom and sound were active at balanced quality. FPS is 1000 / mean frame interval, excluding the first three seconds and non-playing frames. No graphics/feedback errors were recorded. The owner confirmed physical controller joining/movement, sound and rumble.

The separate pixel diagnostic exposed an ImageData ownership bug, fixed independently in #149. The final benchmark included that fix; this pacing PR remains unchanged.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `b7eab94b94f931ac86dade7f0a84afdd020c5143`, changing 3 files against `1fd6ef470dfdfd43b3385fa7ef43feddd1debd06`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
