### PR TITLE
fix(ios): support V8 14 native bridge APIs

### DIFF
--- a/packages/canvas/platforms/ios/build.xcconfig
+++ b/packages/canvas/platforms/ios/build.xcconfig
@@ -3,7 +3,7 @@ OTHER_LDFLAGS[sdk=xros*] = $(inherited) -framework Foundation -framework CanvasN
 OTHER_LDFLAGS[sdk=xrsimulator*] = $(inherited) -framework Foundation -framework CanvasNative -framework Metal
 OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Foundation -framework CanvasNative -framework Metal
 
-CLANG_CXX_LANGUAGE_STANDARD = c++17
+CLANG_CXX_LANGUAGE_STANDARD = c++20
 
 GLES_SILENCE_DEPRECATION = 1
 

--- a/packages/canvas/platforms/ios/src/cpp/CanvasJSIModule.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/CanvasJSIModule.cpp
@@ -554,7 +554,7 @@ void CanvasJSIModule::CreateImageBitmap(const v8::FunctionCallbackInfo<v8::Value
 							auto asset_data = static_cast<ImageBitmapData *>(func->data);
 							
 							auto bitmap = new ImageBitmapImpl(asset_data->asset_);
-							auto external = v8::External::New(isolate, bitmap);
+							auto external = canvas::NewExternal(isolate, bitmap);
 							
 							auto ret = ImageBitmapImpl::NewInstance(isolate, external);
 							
@@ -657,7 +657,7 @@ void CanvasJSIModule::CreateImageBitmap(const v8::FunctionCallbackInfo<v8::Value
 				
 				
 				auto bitmap = new ImageBitmapImpl(ret);
-				auto data = v8::External::New(isolate, bitmap);
+				auto data = canvas::NewExternal(isolate, bitmap);
 				
 				auto object = ImageBitmapImpl::NewInstance(isolate, data);
 				
@@ -677,7 +677,7 @@ void CanvasJSIModule::CreateImageBitmap(const v8::FunctionCallbackInfo<v8::Value
 				
 				
 				auto bitmap = new ImageBitmapImpl(ret);
-				auto data = v8::External::New(isolate, bitmap);
+				auto data = canvas::NewExternal(isolate, bitmap);
 				auto object = ImageBitmapImpl::NewInstance(isolate, data);
 				
 				retArgs[1] = object;
@@ -719,7 +719,7 @@ void CanvasJSIModule::CreateImageBitmap(const v8::FunctionCallbackInfo<v8::Value
 				
 				
 				auto bitmap = new ImageBitmapImpl(ret);
-				auto data = v8::External::New(isolate, bitmap);
+				auto data = canvas::NewExternal(isolate, bitmap);
 				auto object = ImageBitmapImpl::NewInstance(isolate, data);
 				
 				retArgs[1] = object;
@@ -742,7 +742,7 @@ void CanvasJSIModule::CreateImageBitmap(const v8::FunctionCallbackInfo<v8::Value
 				
 				
 				auto bitmap = new ImageBitmapImpl(ret);
-				auto data = v8::External::New(isolate, bitmap);
+				auto data = canvas::NewExternal(isolate, bitmap);
 				auto object = ImageBitmapImpl::NewInstance(isolate, data);
 				
 				retArgs[1] = object;

--- a/packages/canvas/platforms/ios/src/cpp/Common.h
+++ b/packages/canvas/platforms/ios/src/cpp/Common.h
@@ -28,3 +28,85 @@ extern "C" {
 #include <thread>
 #endif
 
+namespace canvas {
+inline void* GetAlignedPointer(v8::Local<v8::Object> object, int index) {
+#if V8_MAJOR_VERSION >= 14
+    return object->GetAlignedPointerFromInternalField(index, v8::kEmbedderDataTypeTagDefault);
+#else
+    return object->GetAlignedPointerFromInternalField(index);
+#endif
+}
+inline void SetAlignedPointer(v8::Local<v8::Object> object, int index, void* value) {
+#if V8_MAJOR_VERSION >= 14
+    object->SetAlignedPointerInInternalField(index, value, v8::kEmbedderDataTypeTagDefault);
+#else
+    object->SetAlignedPointerInInternalField(index, value);
+#endif
+}
+inline v8::Local<v8::External> NewExternal(v8::Isolate* isolate, void* value) {
+#if V8_MAJOR_VERSION >= 14
+    return v8::External::New(isolate, value, v8::kExternalPointerTypeTagDefault);
+#else
+    return v8::External::New(isolate, value);
+#endif
+}
+inline void* ExternalValue(v8::Local<v8::External> value) {
+#if V8_MAJOR_VERSION >= 14
+    return value->Value(v8::kExternalPointerTypeTagDefault);
+#else
+    return value->Value();
+#endif
+}
+}
+
+// V8 14 removed the legacy fast typed-array callbacks. Jitless Apple builds
+// use the existing FunctionCallback implementations instead.
+#if V8_MAJOR_VERSION >= 14
+#define CANVAS_FAST_FUNCTION(callback) (v8::CFunction{})
+#else
+#define CANVAS_FAST_FUNCTION(callback) v8::CFunction::Make(callback)
+#endif
+
+namespace canvas {
+inline void SetAccessor(v8::Local<v8::ObjectTemplate> object, v8::Local<v8::Name> name,
+    v8::AccessorNameGetterCallback getter, v8::AccessorNameSetterCallback setter = nullptr,
+    v8::Local<v8::Value> data = {}, v8::PropertyAttribute attributes = v8::None) {
+#if V8_MAJOR_VERSION >= 14
+    object->SetNativeDataProperty(name, getter, setter, data, attributes);
+#else
+    object->SetAccessor(name, getter, setter, data, v8::DEFAULT, attributes);
+#endif
+}
+template <typename T>
+inline v8::Local<v8::Object> Receiver(const v8::PropertyCallbackInfo<T>& info) {
+#if V8_MAJOR_VERSION >= 14
+    return info.Holder();
+#else
+    return info.This();
+#endif
+}
+template <typename T>
+inline v8::Local<v8::Object> Receiver(const v8::FunctionCallbackInfo<T>& info) {
+    return info.This();
+}
+}
+
+namespace canvas {
+inline size_t Utf8Length(v8::Local<v8::String> text, v8::Isolate* isolate) {
+#if V8_MAJOR_VERSION >= 14
+    return text->Utf8LengthV2(isolate);
+#else
+    return text->Utf8Length(isolate);
+#endif
+}
+inline void WriteUtf8(v8::Local<v8::String> text, v8::Isolate* isolate, char* buffer,
+    size_t capacity, bool terminate) {
+#if V8_MAJOR_VERSION >= 14
+    text->WriteUtf8V2(isolate, buffer, capacity,
+        terminate ? v8::String::WriteFlags::kNullTerminate : v8::String::WriteFlags::kNone);
+#else
+    text->WriteUtf8(isolate, buffer, static_cast<int>(capacity), nullptr,
+        terminate ? v8::String::PRESERVE_ONE_BYTE_NULL : v8::String::NO_NULL_TERMINATION);
+#endif
+}
+}

--- a/packages/canvas/platforms/ios/src/cpp/Helpers.h
+++ b/packages/canvas/platforms/ios/src/cpp/Helpers.h
@@ -171,7 +171,11 @@ static void SetFastMethod(v8::Isolate *isolate,
                                       0,
                                       v8::ConstructorBehavior::kThrow,
                                       v8::SideEffectType::kHasSideEffect,
+#if V8_MAJOR_VERSION >= 14
+                                      nullptr);
+#else
                                       c_function);
+#endif
     // kInternalized strings are created in the old space.
     const v8::NewStringType type = v8::NewStringType::kInternalized;
     v8::Local<v8::String> name_string =
@@ -189,6 +193,10 @@ static void SetFastMethodWithOverLoads(v8::Isolate *isolate,
                                        const v8::CFunction *method_overloads,
                                        v8::Local<v8::Value> data) {
 
+#if V8_MAJOR_VERSION >= 14
+    auto t = v8::FunctionTemplate::New(isolate, slow_callback, data,
+        v8::Local<v8::Signature>(), 0, v8::ConstructorBehavior::kThrow);
+#else
     auto len = NUM(&method_overloads);
     v8::Local<v8::FunctionTemplate> t =
             v8::FunctionTemplate::NewWithCFunctionOverloads(isolate,
@@ -199,6 +207,7 @@ static void SetFastMethodWithOverLoads(v8::Isolate *isolate,
                                                             v8::ConstructorBehavior::kThrow,
                                                             v8::SideEffectType::kHasSideEffect,
                                                             {method_overloads, len});
+#endif
     // kInternalized strings are created in the old space.
     const v8::NewStringType type = v8::NewStringType::kInternalized;
     v8::Local<v8::String> name_string =
@@ -213,7 +222,7 @@ static void SetFastMethod(v8::Local<v8::Context> context,
                           v8::FunctionCallback slow_callback,
                           const v8::CFunction *c_function,
                           v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
-    v8::Isolate *isolate = context->GetIsolate();
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
     v8::Local<v8::Function> function =
             v8::FunctionTemplate::New(isolate,
                                       slow_callback,
@@ -237,7 +246,7 @@ static void SetFastMethodNoSideEffect(v8::Local<v8::Context> context,
                                       v8::FunctionCallback slow_callback,
                                       const v8::CFunction *c_function,
                                       v8::Local<v8::Value> data) {
-    v8::Isolate *isolate = context->GetIsolate();
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
     v8::Local<v8::Function> function =
             v8::FunctionTemplate::New(isolate,
                                       slow_callback,
@@ -269,7 +278,11 @@ static void SetFastMethodNoSideEffect(v8::Isolate *isolate,
                                       0,
                                       v8::ConstructorBehavior::kThrow,
                                       v8::SideEffectType::kHasNoSideEffect,
+#if V8_MAJOR_VERSION >= 14
+                                      nullptr);
+#else
                                       c_function);
+#endif
     // kInternalized strings are created in the old space.
     const v8::NewStringType type = v8::NewStringType::kInternalized;
     v8::Local<v8::String> name_string =

--- a/packages/canvas/platforms/ios/src/cpp/ImageAssetImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/ImageAssetImpl.cpp
@@ -33,7 +33,7 @@ void ImageAssetImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isola
 }
 
 ImageAssetImpl *ImageAssetImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -53,17 +53,17 @@ v8::Local<v8::FunctionTemplate> ImageAssetImpl::GetCtor(v8::Isolate *isolate) {
     
     auto tmpl = ctorTmpl->InstanceTemplate();
     tmpl->SetInternalFieldCount(2);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
                       ConvertToV8String(isolate, "width"),
                       GetWidth);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
                       ConvertToV8String(isolate, "height"),
                       GetHeight);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
                       ConvertToV8String(isolate, "error"),
                       GetError);
     
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
                       ConvertToV8String(isolate, "__addr"),
                       GetAddr);
     
@@ -138,7 +138,7 @@ void ImageAssetImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
     
     SetNativeType(object, NativeType::ImageAsset);
     
-    ret->SetAlignedPointerInInternalField(0, object);
+    canvas::SetAlignedPointer(ret, 0, object);
     
     object->BindFinalizer(isolate, ret);
     
@@ -146,9 +146,9 @@ void ImageAssetImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 }
 
 void
-ImageAssetImpl::GetWidth(v8::Local<v8::String> name,
+ImageAssetImpl::GetWidth(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_image_asset_width(ptr->GetImageAsset());
         info.GetReturnValue().Set(ret);
@@ -158,9 +158,9 @@ ImageAssetImpl::GetWidth(v8::Local<v8::String> name,
 }
 
 void
-ImageAssetImpl::GetHeight(v8::Local<v8::String> name,
+ImageAssetImpl::GetHeight(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_image_asset_height(ptr->GetImageAsset());
         info.GetReturnValue().Set(ret);
@@ -171,9 +171,9 @@ ImageAssetImpl::GetHeight(v8::Local<v8::String> name,
 
 
 void
-ImageAssetImpl::GetAddr(v8::Local<v8::String> name,
+ImageAssetImpl::GetAddr(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto ret = std::to_string(canvas_native_image_asset_get_addr(ptr->GetImageAsset()));
@@ -200,9 +200,9 @@ ImageAssetImpl::GetReference(const v8::FunctionCallbackInfo<v8::Value> &args) {
 }
 
 void
-ImageAssetImpl::GetError(v8::Local<v8::String> name,
+ImageAssetImpl::GetError(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_image_asset_get_error(ptr->GetImageAsset());
         auto isolate = info.GetIsolate();
@@ -608,7 +608,6 @@ void ImageAssetImpl::FromBytesCb(const v8::FunctionCallbackInfo<v8::Value> &args
 
 #endif
 
-
 #ifdef __APPLE__
 
     auto cache = Caches::Get(isolate);
@@ -742,7 +741,6 @@ void ImageAssetImpl::FromEncodedBytesCb(const v8::FunctionCallbackInfo<v8::Value
     });
 
 #endif
-
 
 #ifdef __APPLE__
 

--- a/packages/canvas/platforms/ios/src/cpp/ImageAssetImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/ImageAssetImpl.h
@@ -33,18 +33,18 @@ public:
 
     static void Ctor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    static void GetWidth(v8::Local<v8::String> name,
+    static void GetWidth(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetHeight(v8::Local<v8::String> name,
+    static void GetHeight(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetAddr(v8::Local<v8::String> name,
+    static void GetAddr(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info);
 
     static void GetReference(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    static void GetError(v8::Local<v8::String> name,
+    static void GetError(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 //    static void Scale(const v8::FunctionCallbackInfo<v8::Value> &args);

--- a/packages/canvas/platforms/ios/src/cpp/ImageBitmapImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/ImageBitmapImpl.cpp
@@ -35,7 +35,7 @@ void ImageBitmapImpl::FromAsset(const v8::FunctionCallbackInfo<v8::Value> &args)
         auto ptr = ImageAssetImpl::GetPointer(asset.As<v8::Object>());
         auto ret = canvas_native_image_asset_reference(ptr->GetImageAsset());
         auto bitmap = new ImageBitmapImpl(ret);
-        auto data = v8::External::New(isolate, bitmap);
+        auto data = canvas::NewExternal(isolate, bitmap);
         auto object = ImageBitmapImpl::NewInstance(isolate, data);
         args.GetReturnValue().Set(object);
         return;
@@ -44,7 +44,7 @@ void ImageBitmapImpl::FromAsset(const v8::FunctionCallbackInfo<v8::Value> &args)
 }
 
 ImageBitmapImpl *ImageBitmapImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -67,16 +67,16 @@ v8::Local<v8::FunctionTemplate> ImageBitmapImpl::GetCtor(v8::Isolate *isolate) {
     auto tmpl = ctorTmpl->InstanceTemplate();
 
     tmpl->SetInternalFieldCount(2);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "width"), GetWidth);
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "height"), GetHeight);
 
     tmpl->Set(
             ConvertToV8String(isolate, "close"), v8::FunctionTemplate::New(isolate, Close));
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "__addr"),
             GetAddr);
 
@@ -90,9 +90,9 @@ v8::Local<v8::FunctionTemplate> ImageBitmapImpl::GetCtor(v8::Isolate *isolate) {
 }
 
 void
-ImageBitmapImpl::GetWidth(v8::Local<v8::String> name,
+ImageBitmapImpl::GetWidth(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr && !ptr->closed_) {
         auto ret = canvas_native_image_asset_width(ptr->GetImageAsset());
         info.GetReturnValue().Set(ret);
@@ -102,9 +102,9 @@ ImageBitmapImpl::GetWidth(v8::Local<v8::String> name,
 }
 
 void
-ImageBitmapImpl::GetHeight(v8::Local<v8::String> name,
+ImageBitmapImpl::GetHeight(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr && !ptr->closed_) {
         auto ret = canvas_native_image_asset_height(ptr->GetImageAsset());
         info.GetReturnValue().Set(ret);
@@ -215,9 +215,9 @@ ImageBitmapImpl::HandleOptions(v8::Isolate *isolate, const v8::Local<v8::Value> 
 
 
 void
-ImageBitmapImpl::GetAddr(v8::Local<v8::String> name,
+ImageBitmapImpl::GetAddr(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto ret = std::to_string(canvas_native_image_asset_get_addr(ptr->GetImageAsset()));

--- a/packages/canvas/platforms/ios/src/cpp/ImageBitmapImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/ImageBitmapImpl.h
@@ -31,13 +31,13 @@ public:
         auto object = ImageBitmapImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 
-        auto ptr = asset->Value();
+        auto ptr = canvas::ExternalValue(asset);
         auto impl = static_cast<ObjectWrapperImpl *>(ptr);
 
         SetNativeType(impl, NativeType::ImageBitmap);
 
 
-        object->SetAlignedPointerInInternalField(0, ptr);
+        canvas::SetAlignedPointer(object, 0, ptr);
 
         impl->BindFinalizer(isolate, object);
 
@@ -54,15 +54,15 @@ public:
 
     static v8::Local<v8::FunctionTemplate> GetCtor(v8::Isolate *isolate);
 
-    static void GetWidth(v8::Local<v8::String> name,
+    static void GetWidth(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetHeight(v8::Local<v8::String> name,
+    static void GetHeight(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info);
 
     static void GetReference(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    static void GetAddr(v8::Local<v8::String> name,
+    static void GetAddr(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info);
 
     static void Close(const v8::FunctionCallbackInfo<v8::Value> &args);

--- a/packages/canvas/platforms/ios/src/cpp/ObjectWrapperImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/ObjectWrapperImpl.h
@@ -34,7 +34,7 @@ public:
     static void SetNativeType(const v8::Local<v8::Object> &obj, NativeType type) {
         if (!obj.IsEmpty() && !obj->IsNullOrUndefined() && obj->IsObject() &&
             obj.As<v8::Object>()->InternalFieldCount() > 1) {
-            auto wrapper = obj.As<v8::Object>()->GetAlignedPointerFromInternalField(0);
+            auto wrapper = canvas::GetAlignedPointer(obj.As<v8::Object>(), 0);
             if (wrapper != nullptr) {
                 ((ObjectWrapperImpl *) wrapper)->type_ = type;
             }
@@ -45,7 +45,7 @@ public:
     inline static NativeType GetNativeType(const v8::Local<v8::Value> &obj) {
         if (!obj.IsEmpty() && !obj->IsNullOrUndefined() && obj->IsObject() &&
             obj.As<v8::Object>()->InternalFieldCount() > 1) {
-            auto info = obj.As<v8::Object>()->GetAlignedPointerFromInternalField(0);
+            auto info = canvas::GetAlignedPointer(obj.As<v8::Object>(), 0);
 
             if (info != nullptr) {
                 auto value = static_cast<ObjectWrapperImpl *>(info);

--- a/packages/canvas/platforms/ios/src/cpp/TextDecoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/TextDecoderImpl.cpp
@@ -23,7 +23,7 @@ void TextDecoderImpl::Init(const v8::Local<v8::Object> &canvasModule, v8::Isolat
 }
 
 TextDecoderImpl *TextDecoderImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -47,7 +47,7 @@ v8::Local<v8::FunctionTemplate> TextDecoderImpl::GetCtor(v8::Isolate *isolate) {
 
     auto tmpl = ctorTmpl->InstanceTemplate();
     tmpl->SetInternalFieldCount(2);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "encoding"),
             Encoding);
     tmpl->Set(
@@ -87,7 +87,7 @@ void TextDecoderImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
     auto decoder = new TextDecoderImpl(encoder);
 
-    ret->SetAlignedPointerInInternalField(0, decoder);
+    canvas::SetAlignedPointer(ret, 0, decoder);
 
     decoder->BindFinalizer(isolate, ret);
 
@@ -96,9 +96,9 @@ void TextDecoderImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 }
 
 void
-TextDecoderImpl::Encoding(v8::Local<v8::String> name,
+TextDecoderImpl::Encoding(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto encoding = canvas_native_text_decoder_get_encoding(ptr->GetTextDecoder());

--- a/packages/canvas/platforms/ios/src/cpp/TextDecoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/TextDecoderImpl.h
@@ -33,7 +33,7 @@ public:
     static void DecodeAsync(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void
-    Encoding(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value> &info);
+    Encoding(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
     TextDecoder *decoder_;

--- a/packages/canvas/platforms/ios/src/cpp/TextEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/TextEncoderImpl.cpp
@@ -23,7 +23,7 @@ void TextEncoderImpl::Init(const v8::Local<v8::Object>& canvasModule, v8::Isolat
 
 
 TextEncoderImpl *TextEncoderImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -44,7 +44,7 @@ v8::Local<v8::FunctionTemplate> TextEncoderImpl::GetCtor(v8::Isolate *isolate) {
 
     auto tmpl = ctorTmpl->InstanceTemplate();
     tmpl->SetInternalFieldCount(2);
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "encoding"),
             Encoding);
     tmpl->Set(
@@ -79,7 +79,7 @@ void TextEncoderImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
     auto txtEncoder = new TextEncoderImpl(encoder);
 
-    ret->SetAlignedPointerInInternalField(0, txtEncoder);
+    canvas::SetAlignedPointer(ret, 0, txtEncoder);
 
     txtEncoder->BindFinalizer(isolate, ret);
 
@@ -89,9 +89,9 @@ void TextEncoderImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
 
 void
-TextEncoderImpl::Encoding(v8::Local<v8::String> name,
+TextEncoderImpl::Encoding(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto encoding = canvas_native_text_encoder_get_encoding(ptr->GetTextEncoder());

--- a/packages/canvas/platforms/ios/src/cpp/TextEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/TextEncoderImpl.h
@@ -30,7 +30,7 @@ public:
     static void Encode(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void
-    Encoding(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value> &info);
+    Encoding(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value> &info);
 
 private:
     TextEncoder* encoder_;

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasGradient.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasGradient.cpp
@@ -21,7 +21,7 @@ void CanvasGradient::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isola
 }
 
 CanvasGradient *CanvasGradient::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasGradient.h
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasGradient.h
@@ -32,7 +32,7 @@ public:
         auto object = CanvasGradient::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(gradient, NativeType::CanvasGradient);
-        object->SetAlignedPointerInInternalField(0, gradient);
+        canvas::SetAlignedPointer(object, 0, gradient);
         gradient->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasPattern.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasPattern.cpp
@@ -21,10 +21,10 @@ void CanvasPattern::Init(const v8::Local<v8::Object> &canvasModule, v8::Isolate 
 }
 
 v8::CFunction CanvasPattern::fast_set_transform_(
-        v8::CFunction::Make(CanvasPattern::FastSetTransform));
+        CANVAS_FAST_FUNCTION(CanvasPattern::FastSetTransform));
 
 CanvasPattern *CanvasPattern::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasPattern.h
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasPattern.h
@@ -31,7 +31,7 @@ public:
         auto object = CanvasPattern::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(pattern, NativeType::CanvasPattern);
-        object->SetAlignedPointerInInternalField(0, pattern);
+        canvas::SetAlignedPointer(object, 0, pattern);
         pattern->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.cpp
@@ -341,33 +341,33 @@ namespace {
 }
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_start_raf_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::__FastStartRaf));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::__FastStartRaf));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_stop_raf_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::__FastStopRaf));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::__FastStopRaf));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_draw_point_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastDrawPoint));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastDrawPoint));
 
 //v8::CFunction CanvasRenderingContext2DImpl::fast_draw_atlas_(
-//        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastDrawAtlas));
+//        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastDrawAtlas));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_ellipse_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastEllipse));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastEllipse));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_bezier_curve_to_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastBezierCurveTo));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastBezierCurveTo));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_clip_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastClip));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastClip));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_clip_rule_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastClipRule));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastClipRule));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_clip_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastClipPath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastClipPath));
 
 
 const v8::CFunction fast_clip_overloads_[] = {
@@ -378,27 +378,27 @@ const v8::CFunction fast_clip_overloads_[] = {
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_close_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastClosePath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastClosePath));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_begin_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastBeginPath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastBeginPath));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_arc_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastArc));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastArc));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_arc_to_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastArcTo));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastArcTo));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_draw_image_dx_dy_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastDrawImageDxDy));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastDrawImageDxDy));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_draw_image_dx_dy_dw_dh_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastDrawImageDxDyDwDh));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastDrawImageDxDyDwDh));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_draw_image_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastDrawImage));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastDrawImage));
 
 
 const v8::CFunction fast_draw_overloads_[] = {
@@ -409,45 +409,45 @@ const v8::CFunction fast_draw_overloads_[] = {
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_save_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastSave));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastSave));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_restore_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRestore));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRestore));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_translate_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastTranslate));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastTranslate));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_clear_rect_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastClearRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastClearRect));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_rect_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFillRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFillRect));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_oval_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFillOval));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFillOval));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_stroke_rect_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastStrokeRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastStrokeRect));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_stroke_oval_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastStrokeOval));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastStrokeOval));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_rotate_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRotate));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRotate));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFill));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFill));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFillPath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFillPath));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_rule_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFillRule));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFillRule));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_fill_path_rule_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastFillPathRule));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastFillPathRule));
 
 const v8::CFunction fast_fill_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_fill_path_rule_,
@@ -459,10 +459,10 @@ const v8::CFunction fast_fill_overloads_[] = {
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_put_image_data_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastPutImageData));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastPutImageData));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_put_image_data_dx_dy_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastPutImageDataDxDy));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastPutImageDataDxDy));
 
 const v8::CFunction fast_put_image_data_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_put_image_data_,
@@ -471,10 +471,10 @@ const v8::CFunction fast_put_image_data_overloads_[] = {
 };
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_stroke_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastStroke));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastStroke));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_stroke_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastStrokePath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastStrokePath));
 
 const v8::CFunction fast_stroke_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_stroke_,
@@ -482,13 +482,13 @@ const v8::CFunction fast_stroke_overloads_[] = {
 };
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_is_point_in_path_xy_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastIsPointInPathXY));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastIsPointInPathXY));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_is_point_in_path_xy_rule_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastIsPointInPathXYRule));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastIsPointInPathXYRule));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_is_point_in_path_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastIsPointInPath));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastIsPointInPath));
 
 const v8::CFunction fast_is_point_in_path_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_is_point_in_path_,
@@ -498,10 +498,10 @@ const v8::CFunction fast_is_point_in_path_overloads_[] = {
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_is_point_in_stroke_xy_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastIsPointInStrokeXY));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastIsPointInStrokeXY));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_is_point_in_stroke_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastIsPointInStroke));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastIsPointInStroke));
 
 const v8::CFunction fast_is_point_in_stroke_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_is_point_in_stroke_,
@@ -509,21 +509,21 @@ const v8::CFunction fast_is_point_in_stroke_overloads_[] = {
 };
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_line_to_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastLineTo));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastLineTo));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_move_to_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastMoveTo));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastMoveTo));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_quadratic_curve_to_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastQuadraticCurveTo));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastQuadraticCurveTo));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_round_rect_array_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRoundRectArray));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRoundRectArray));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_round_rect_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRoundRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRoundRect));
 
 const v8::CFunction fast_round_rect_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_round_rect_array_,
@@ -532,20 +532,20 @@ const v8::CFunction fast_round_rect_overloads_[] = {
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_rect_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRect));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_scale_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastRect));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastRect));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_set_line_dash_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastSetLineDash));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastSetLineDash));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_set_transform_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastSetTransform));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastSetTransform));
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_set_transform_abcdef_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastSetTransformABCDEF));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastSetTransformABCDEF));
 
 const v8::CFunction fast_set_transform_overloads_[] = {
         CanvasRenderingContext2DImpl::fast_set_transform_abcdef_,
@@ -553,11 +553,11 @@ const v8::CFunction fast_set_transform_overloads_[] = {
 };
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_transform_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastTransform));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastTransform));
 
 
 v8::CFunction CanvasRenderingContext2DImpl::fast_reset_transform_(
-        v8::CFunction::Make(CanvasRenderingContext2DImpl::FastResetTransform));
+        CANVAS_FAST_FUNCTION(CanvasRenderingContext2DImpl::FastResetTransform));
 
 
 CanvasRenderingContext2DImpl::CanvasRenderingContext2DImpl(
@@ -595,7 +595,7 @@ void CanvasRenderingContext2DImpl::Init(v8::Local<v8::Object> canvasModule, v8::
 
 CanvasRenderingContext2DImpl *
 CanvasRenderingContext2DImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -657,81 +657,81 @@ v8::Local<v8::FunctionTemplate> CanvasRenderingContext2DImpl::GetCtor(v8::Isolat
               v8::FunctionTemplate::New(isolate, __GetPointer));
     tmpl->Set(ConvertToV8String(isolate, "__resize"), v8::FunctionTemplate::New(isolate, __Resize));
 
-    tmpl->SetAccessor(ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
                       SetContinuousRenderMode,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
 
-    tmpl->SetAccessor(ConvertToV8String(isolate, "filter"), GetFilter, SetFilter,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "filter"), GetFilter, SetFilter,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "font"), GetFont, SetFont,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "font"), GetFont, SetFont,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "letterSpacing"), GetLetterSpacing,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "letterSpacing"), GetLetterSpacing,
                       SetLetterSpacing,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "wordSpacing"), GetWordSpacing, SetWordSpacing,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "wordSpacing"), GetWordSpacing, SetWordSpacing,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "globalAlpha"), GetGlobalAlpha, SetGlobalAlpha,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "globalAlpha"), GetGlobalAlpha, SetGlobalAlpha,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "imageSmoothingEnabled"), GetImageSmoothingEnabled,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "imageSmoothingEnabled"), GetImageSmoothingEnabled,
                       SetImageSmoothingEnabled,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "imageSmoothingQuality"), GetImageSmoothingQuality,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "imageSmoothingQuality"), GetImageSmoothingQuality,
                       SetImageSmoothingQuality,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "lineDashOffset"), GetLineDashOffset,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "lineDashOffset"), GetLineDashOffset,
                       SetLineDashOffset,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "lineJoin"), GetLineJoin, SetLineJoin,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "lineJoin"), GetLineJoin, SetLineJoin,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "lineCap"), GetLineCap, SetLineCap,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "lineCap"), GetLineCap, SetLineCap,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "miterLimit"), GetMiterLimit, SetMiterLimit,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "miterLimit"), GetMiterLimit, SetMiterLimit,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "shadowColor"), GetShadowColor, SetShadowColor,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "shadowColor"), GetShadowColor, SetShadowColor,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "shadowBlur"), GetShadowBlur, SetShadowBlur,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "shadowBlur"), GetShadowBlur, SetShadowBlur,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "shadowOffsetX"), GetShadowOffsetX,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "shadowOffsetX"), GetShadowOffsetX,
                       SetShadowOffsetX,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "shadowOffsetY"), GetShadowOffsetY,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "shadowOffsetY"), GetShadowOffsetY,
                       SetShadowOffsetY,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "textAlign"), GetTextAlign, SetTextAlign,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "textAlign"), GetTextAlign, SetTextAlign,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "textBaseline"), GetTextBaseline,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "textBaseline"), GetTextBaseline,
                       SetTextBaseline,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "globalCompositeOperation"),
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "globalCompositeOperation"),
                       GetGlobalCompositeOperation, SetGlobalCompositeOperation,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "fillStyle"), GetFillStyle, SetFillStyle,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "fillStyle"), GetFillStyle, SetFillStyle,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "strokeStyle"), GetStrokeStyle, SetStrokeStyle,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "strokeStyle"), GetStrokeStyle, SetStrokeStyle,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "lineWidth"), GetLineWidth, SetLineWidth,
-                      v8::Local<v8::Value>(), v8::PROHIBITS_OVERWRITING,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "lineWidth"), GetLineWidth, SetLineWidth,
+                      v8::Local<v8::Value>(),
                       v8::PropertyAttribute::DontDelete);
 
 
@@ -921,9 +921,9 @@ void CanvasRenderingContext2DImpl::__StopRaf(const v8::FunctionCallbackInfo<v8::
 }
 
 
-void CanvasRenderingContext2DImpl::GetContinuousRenderMode(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetContinuousRenderMode(v8::Local<v8::Name> property,
                                                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(false);
         return;
@@ -931,10 +931,10 @@ void CanvasRenderingContext2DImpl::GetContinuousRenderMode(v8::Local<v8::String>
     info.GetReturnValue().Set(ptr->continuousRender_);
 }
 
-void CanvasRenderingContext2DImpl::SetContinuousRenderMode(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetContinuousRenderMode(v8::Local<v8::Name> property,
                                                            v8::Local<v8::Value> value,
                                                            const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1074,9 +1074,9 @@ void CanvasRenderingContext2DImpl::__Resize(const v8::FunctionCallbackInfo<v8::V
 }
 
 
-void CanvasRenderingContext2DImpl::GetFilter(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetFilter(v8::Local<v8::Name> property,
                                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
         return;
@@ -1087,10 +1087,10 @@ void CanvasRenderingContext2DImpl::GetFilter(v8::Local<v8::String> property,
     canvas_native_string_destroy((char *) filter);
 }
 
-void CanvasRenderingContext2DImpl::SetFilter(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetFilter(v8::Local<v8::Name> property,
                                              v8::Local<v8::Value> value,
                                              const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1099,9 +1099,9 @@ void CanvasRenderingContext2DImpl::SetFilter(v8::Local<v8::String> property,
     canvas_native_context_set_filter(ptr->GetContext(), val.c_str());
 }
 
-void CanvasRenderingContext2DImpl::GetFont(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetFont(v8::Local<v8::Name> property,
                                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
         return;
@@ -1125,10 +1125,10 @@ void CanvasRenderingContext2DImpl::GetFont(v8::Local<v8::String> property,
     canvas_native_string_destroy((char *) font);
 }
 
-void CanvasRenderingContext2DImpl::SetFont(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetFont(v8::Local<v8::Name> property,
                                            v8::Local<v8::Value> value,
                                            const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1148,9 +1148,9 @@ void CanvasRenderingContext2DImpl::SetFont(v8::Local<v8::String> property,
 }
 
 
-void CanvasRenderingContext2DImpl::GetLetterSpacing(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLetterSpacing(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
         return;
@@ -1162,10 +1162,10 @@ void CanvasRenderingContext2DImpl::GetLetterSpacing(v8::Local<v8::String> proper
     canvas_native_string_destroy((char *) font);
 }
 
-void CanvasRenderingContext2DImpl::SetLetterSpacing(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLetterSpacing(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1177,9 +1177,9 @@ void CanvasRenderingContext2DImpl::SetLetterSpacing(v8::Local<v8::String> proper
 }
 
 
-void CanvasRenderingContext2DImpl::GetWordSpacing(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetWordSpacing(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
         return;
@@ -1191,10 +1191,10 @@ void CanvasRenderingContext2DImpl::GetWordSpacing(v8::Local<v8::String> property
     canvas_native_string_destroy((char *) font);
 }
 
-void CanvasRenderingContext2DImpl::SetWordSpacing(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetWordSpacing(v8::Local<v8::Name> property,
                                                   v8::Local<v8::Value> value,
                                                   const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1206,9 +1206,9 @@ void CanvasRenderingContext2DImpl::SetWordSpacing(v8::Local<v8::String> property
 }
 
 
-void CanvasRenderingContext2DImpl::GetGlobalAlpha(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetGlobalAlpha(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(1);
         return;
@@ -1217,10 +1217,10 @@ void CanvasRenderingContext2DImpl::GetGlobalAlpha(v8::Local<v8::String> property
     info.GetReturnValue().Set((double) alpha);
 }
 
-void CanvasRenderingContext2DImpl::SetGlobalAlpha(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetGlobalAlpha(v8::Local<v8::Name> property,
                                                   v8::Local<v8::Value> value,
                                                   const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1230,9 +1230,9 @@ void CanvasRenderingContext2DImpl::SetGlobalAlpha(v8::Local<v8::String> property
                                            (float) value->NumberValue(context).ToChecked());
 }
 
-void CanvasRenderingContext2DImpl::GetImageSmoothingEnabled(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetImageSmoothingEnabled(v8::Local<v8::Name> property,
                                                             const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(false);
         return;
@@ -1241,10 +1241,10 @@ void CanvasRenderingContext2DImpl::GetImageSmoothingEnabled(v8::Local<v8::String
     info.GetReturnValue().Set(enabled);
 }
 
-void CanvasRenderingContext2DImpl::SetImageSmoothingEnabled(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetImageSmoothingEnabled(v8::Local<v8::Name> property,
                                                             v8::Local<v8::Value> value,
                                                             const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1253,9 +1253,9 @@ void CanvasRenderingContext2DImpl::SetImageSmoothingEnabled(v8::Local<v8::String
                                                       value->BooleanValue(isolate));
 }
 
-void CanvasRenderingContext2DImpl::GetImageSmoothingQuality(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetImageSmoothingQuality(v8::Local<v8::Name> property,
                                                             const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
         return;
@@ -1269,10 +1269,10 @@ void CanvasRenderingContext2DImpl::GetImageSmoothingQuality(v8::Local<v8::String
 
 }
 
-void CanvasRenderingContext2DImpl::SetImageSmoothingQuality(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetImageSmoothingQuality(v8::Local<v8::Name> property,
                                                             v8::Local<v8::Value> value,
                                                             const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1281,9 +1281,9 @@ void CanvasRenderingContext2DImpl::SetImageSmoothingQuality(v8::Local<v8::String
     canvas_native_context_set_image_smoothing_quality(ptr->GetContext(), quality.c_str());
 }
 
-void CanvasRenderingContext2DImpl::GetLineDashOffset(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLineDashOffset(v8::Local<v8::Name> property,
                                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1292,10 +1292,10 @@ void CanvasRenderingContext2DImpl::GetLineDashOffset(v8::Local<v8::String> prope
     info.GetReturnValue().Set((double) offset);
 }
 
-void CanvasRenderingContext2DImpl::SetLineDashOffset(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLineDashOffset(v8::Local<v8::Name> property,
                                                      v8::Local<v8::Value> value,
                                                      const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1306,9 +1306,9 @@ void CanvasRenderingContext2DImpl::SetLineDashOffset(v8::Local<v8::String> prope
 }
 
 
-void CanvasRenderingContext2DImpl::GetLineJoin(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLineJoin(v8::Local<v8::Name> property,
                                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1320,10 +1320,10 @@ void CanvasRenderingContext2DImpl::GetLineJoin(v8::Local<v8::String> property,
     canvas_native_string_destroy((char *) join);
 }
 
-void CanvasRenderingContext2DImpl::SetLineJoin(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLineJoin(v8::Local<v8::Name> property,
                                                v8::Local<v8::Value> value,
                                                const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1332,9 +1332,9 @@ void CanvasRenderingContext2DImpl::SetLineJoin(v8::Local<v8::String> property,
     canvas_native_context_set_line_join(ptr->GetContext(), join.c_str());
 }
 
-void CanvasRenderingContext2DImpl::GetLineCap(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLineCap(v8::Local<v8::Name> property,
                                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1346,10 +1346,10 @@ void CanvasRenderingContext2DImpl::GetLineCap(v8::Local<v8::String> property,
     canvas_native_string_destroy((char *) cap);
 }
 
-void CanvasRenderingContext2DImpl::SetLineCap(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLineCap(v8::Local<v8::Name> property,
                                               v8::Local<v8::Value> value,
                                               const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1359,9 +1359,9 @@ void CanvasRenderingContext2DImpl::SetLineCap(v8::Local<v8::String> property,
 }
 
 
-void CanvasRenderingContext2DImpl::GetMiterLimit(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetMiterLimit(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1370,10 +1370,10 @@ void CanvasRenderingContext2DImpl::GetMiterLimit(v8::Local<v8::String> property,
     info.GetReturnValue().Set((double) limit);
 }
 
-void CanvasRenderingContext2DImpl::SetMiterLimit(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetMiterLimit(v8::Local<v8::Name> property,
                                                  v8::Local<v8::Value> value,
                                                  const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1384,9 +1384,9 @@ void CanvasRenderingContext2DImpl::SetMiterLimit(v8::Local<v8::String> property,
 }
 
 
-void CanvasRenderingContext2DImpl::GetShadowColor(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetShadowColor(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1397,10 +1397,10 @@ void CanvasRenderingContext2DImpl::GetShadowColor(v8::Local<v8::String> property
     canvas_native_string_destroy((char *) color);
 }
 
-void CanvasRenderingContext2DImpl::SetShadowColor(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetShadowColor(v8::Local<v8::Name> property,
                                                   v8::Local<v8::Value> value,
                                                   const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1410,9 +1410,9 @@ void CanvasRenderingContext2DImpl::SetShadowColor(v8::Local<v8::String> property
 }
 
 
-void CanvasRenderingContext2DImpl::GetShadowBlur(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetShadowBlur(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1421,10 +1421,10 @@ void CanvasRenderingContext2DImpl::GetShadowBlur(v8::Local<v8::String> property,
     info.GetReturnValue().Set((double) blur);
 }
 
-void CanvasRenderingContext2DImpl::SetShadowBlur(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetShadowBlur(v8::Local<v8::Name> property,
                                                  v8::Local<v8::Value> value,
                                                  const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1434,9 +1434,9 @@ void CanvasRenderingContext2DImpl::SetShadowBlur(v8::Local<v8::String> property,
                                           (float) value->NumberValue(context).ToChecked());
 }
 
-void CanvasRenderingContext2DImpl::GetShadowOffsetX(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetShadowOffsetX(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1445,10 +1445,10 @@ void CanvasRenderingContext2DImpl::GetShadowOffsetX(v8::Local<v8::String> proper
     info.GetReturnValue().Set((double) x);
 }
 
-void CanvasRenderingContext2DImpl::SetShadowOffsetX(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetShadowOffsetX(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1459,9 +1459,9 @@ void CanvasRenderingContext2DImpl::SetShadowOffsetX(v8::Local<v8::String> proper
 }
 
 
-void CanvasRenderingContext2DImpl::GetShadowOffsetY(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetShadowOffsetY(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1470,10 +1470,10 @@ void CanvasRenderingContext2DImpl::GetShadowOffsetY(v8::Local<v8::String> proper
     info.GetReturnValue().Set((double) y);
 }
 
-void CanvasRenderingContext2DImpl::SetShadowOffsetY(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetShadowOffsetY(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1484,9 +1484,9 @@ void CanvasRenderingContext2DImpl::SetShadowOffsetY(v8::Local<v8::String> proper
 }
 
 
-void CanvasRenderingContext2DImpl::GetTextAlign(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetTextAlign(v8::Local<v8::Name> property,
                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1498,10 +1498,10 @@ void CanvasRenderingContext2DImpl::GetTextAlign(v8::Local<v8::String> property,
     canvas_native_string_destroy((char *) alignment);
 }
 
-void CanvasRenderingContext2DImpl::SetTextAlign(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetTextAlign(v8::Local<v8::Name> property,
                                                 v8::Local<v8::Value> value,
                                                 const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1510,9 +1510,9 @@ void CanvasRenderingContext2DImpl::SetTextAlign(v8::Local<v8::String> property,
     canvas_native_context_set_text_align(ptr->GetContext(), alignment.c_str());
 }
 
-void CanvasRenderingContext2DImpl::GetTextBaseline(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetTextBaseline(v8::Local<v8::Name> property,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1524,10 +1524,10 @@ void CanvasRenderingContext2DImpl::GetTextBaseline(v8::Local<v8::String> propert
 //    canvas_native_string_destroy((char *) baseline);
 }
 
-void CanvasRenderingContext2DImpl::SetTextBaseline(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetTextBaseline(v8::Local<v8::Name> property,
                                                    v8::Local<v8::Value> value,
                                                    const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
 
         return;
@@ -1543,9 +1543,9 @@ void CanvasRenderingContext2DImpl::SetTextBaseline(v8::Local<v8::String> propert
 }
 
 
-void CanvasRenderingContext2DImpl::GetGlobalCompositeOperation(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetGlobalCompositeOperation(v8::Local<v8::Name> property,
                                                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1554,10 +1554,10 @@ void CanvasRenderingContext2DImpl::GetGlobalCompositeOperation(v8::Local<v8::Str
     info.GetReturnValue().Set(operation);
 }
 
-void CanvasRenderingContext2DImpl::SetGlobalCompositeOperation(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetGlobalCompositeOperation(v8::Local<v8::Name> property,
                                                                v8::Local<v8::Value> value,
                                                                const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1574,9 +1574,9 @@ void CanvasRenderingContext2DImpl::SetGlobalCompositeOperation(v8::Local<v8::Str
 }
 
 
-void CanvasRenderingContext2DImpl::GetFillStyle(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetFillStyle(v8::Local<v8::Name> property,
                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1626,10 +1626,10 @@ void CanvasRenderingContext2DImpl::GetFillStyle(v8::Local<v8::String> property,
 
 }
 
-void CanvasRenderingContext2DImpl::SetFillStyle(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetFillStyle(v8::Local<v8::Name> property,
                                                 v8::Local<v8::Value> value,
                                                 const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1647,10 +1647,9 @@ void CanvasRenderingContext2DImpl::SetFillStyle(v8::Local<v8::String> property,
             val = value.As<v8::StringObject>()->ValueOf();
         }
 
-        int len = val->Utf8Length(isolate) + 1;
+        int len = canvas::Utf8Length(val, isolate) + 1;
         if (g_tls_scratch.size() < (size_t) len) g_tls_scratch.resize((size_t) len);
-        val->WriteUtf8(isolate, g_tls_scratch.data(), len, nullptr,
-                       v8::String::WriteOptions::PRESERVE_ONE_BYTE_NULL);
+        canvas::WriteUtf8(val, isolate, g_tls_scratch.data(), len, true);
 
         char *str = g_tls_scratch.data();
 
@@ -1693,9 +1692,9 @@ void CanvasRenderingContext2DImpl::SetFillStyle(v8::Local<v8::String> property,
     }
 }
 
-void CanvasRenderingContext2DImpl::GetStrokeStyle(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetStrokeStyle(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -1745,10 +1744,10 @@ void CanvasRenderingContext2DImpl::GetStrokeStyle(v8::Local<v8::String> property
 }
 
 
-void CanvasRenderingContext2DImpl::SetStrokeStyle(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetStrokeStyle(v8::Local<v8::Name> property,
                                                   v8::Local<v8::Value> value,
                                                   const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1762,10 +1761,9 @@ void CanvasRenderingContext2DImpl::SetStrokeStyle(v8::Local<v8::String> property
             val = value.As<v8::StringObject>()->ValueOf();
         }
 
-        int len = val->Utf8Length(isolate) + 1;
+        int len = canvas::Utf8Length(val, isolate) + 1;
         if (g_tls_scratch.size() < (size_t) len) g_tls_scratch.resize((size_t) len);
-        val->WriteUtf8(isolate, g_tls_scratch.data(), len, nullptr,
-                       v8::String::WriteOptions::PRESERVE_ONE_BYTE_NULL);
+        canvas::WriteUtf8(val, isolate, g_tls_scratch.data(), len, true);
 
         char *str = g_tls_scratch.data();
 
@@ -1808,9 +1806,9 @@ void CanvasRenderingContext2DImpl::SetStrokeStyle(v8::Local<v8::String> property
 }
 
 
-void CanvasRenderingContext2DImpl::GetLineWidth(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLineWidth(v8::Local<v8::Name> property,
                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1823,10 +1821,10 @@ void CanvasRenderingContext2DImpl::GetLineWidth(v8::Local<v8::String> property,
 }
 
 
-void CanvasRenderingContext2DImpl::SetLineWidth(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLineWidth(v8::Local<v8::Name> property,
                                                 v8::Local<v8::Value> value,
                                                 const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1837,9 +1835,9 @@ void CanvasRenderingContext2DImpl::SetLineWidth(v8::Local<v8::String> property,
     canvas_native_context_set_line_width(ptr->GetContext(), lineWidth);
 }
 
-void CanvasRenderingContext2DImpl::GetLineDash(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::GetLineDash(v8::Local<v8::Name> property,
                                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -1860,10 +1858,10 @@ void CanvasRenderingContext2DImpl::GetLineDash(v8::Local<v8::String> property,
 }
 
 
-void CanvasRenderingContext2DImpl::SetLineDash(v8::Local<v8::String> property,
+void CanvasRenderingContext2DImpl::SetLineDash(v8::Local<v8::Name> property,
                                                v8::Local<v8::Value> value,
                                                const v8::PropertyCallbackInfo<void> &info) {
-    CanvasRenderingContext2DImpl *ptr = GetPointer(info.This());
+    CanvasRenderingContext2DImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -2087,7 +2085,7 @@ CanvasRenderingContext2DImpl::CreateImageData(const v8::FunctionCallbackInfo<v8:
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 
 
-            ret->SetAlignedPointerInInternalField(0, data);
+            canvas::SetAlignedPointer(ret, 0, data);
 
             SetNativeType(data, NativeType::ImageData);
 
@@ -2107,7 +2105,7 @@ CanvasRenderingContext2DImpl::CreateImageData(const v8::FunctionCallbackInfo<v8:
         auto ret = ImageDataImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 
-        ret->SetAlignedPointerInInternalField(0, data);
+        canvas::SetAlignedPointer(ret, 0, data);
 
         SetNativeType(data, NativeType::ImageData);
 
@@ -2890,12 +2888,11 @@ CanvasRenderingContext2DImpl::FillText(const v8::FunctionCallbackInfo<v8::Value>
 
     if (!args[0]->IsString()) return;
     auto js_str = args[0].As<v8::String>();
-    const int text_utf8_len = js_str->Utf8Length(isolate);
+    const int text_utf8_len = canvas::Utf8Length(js_str, isolate);
 
     auto &scratch = g_tls_scratch;
     scratch.resize(static_cast<size_t>(text_utf8_len) + 1);
-    js_str->WriteUtf8(isolate, scratch.data(), text_utf8_len, nullptr,
-                      v8::String::NO_NULL_TERMINATION);
+    canvas::WriteUtf8(js_str, isolate, scratch.data(), text_utf8_len, false);
     scratch[text_utf8_len] = '\0';
 
     auto x = static_cast<float>(args[1]->NumberValue(context).ToChecked());
@@ -2961,7 +2958,7 @@ CanvasRenderingContext2DImpl::GetImageData(const v8::FunctionCallbackInfo<v8::Va
         auto ret = ImageDataImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 
-        ret->SetAlignedPointerInInternalField(0, data);
+        canvas::SetAlignedPointer(ret, 0, data);
 
         SetNativeType(data, NativeType::ImageData);
 
@@ -3135,7 +3132,7 @@ CanvasRenderingContext2DImpl::MeasureText(const v8::FunctionCallbackInfo<v8::Val
         }
     }
 
-    const int text_utf8_len = js_str->Utf8Length(isolate);
+    const int text_utf8_len = canvas::Utf8Length(js_str, isolate);
     if (text_utf8_len == 0) return;
 
     auto &scratch = g_tls_scratch;
@@ -3153,8 +3150,7 @@ CanvasRenderingContext2DImpl::MeasureText(const v8::FunctionCallbackInfo<v8::Val
     std::memcpy(p, ptr->cached_word_spacing_.data(), ptr->cached_word_spacing_.size());
     p += ptr->cached_word_spacing_.size();
     *p++ = '|';
-    js_str->WriteUtf8(isolate, p, text_utf8_len, nullptr,
-                      v8::String::NO_NULL_TERMINATION);
+    canvas::WriteUtf8(js_str, isolate, p, text_utf8_len, false);
 
     std::string_view text(p, static_cast<size_t>(text_utf8_len));
     std::string_view cache_key(scratch.data(), prefix_len + static_cast<size_t>(text_utf8_len));
@@ -3181,7 +3177,7 @@ CanvasRenderingContext2DImpl::MeasureText(const v8::FunctionCallbackInfo<v8::Val
 
     auto ret = ptr->tm_ctor_.Get(isolate)->InstanceTemplate()
             ->NewInstance(context).ToLocalChecked();
-    ret->SetAlignedPointerInInternalField(0, data);
+    canvas::SetAlignedPointer(ret, 0, data);
     data->BindFinalizer(isolate, ret);
     SetNativeType(data, NativeType::TextMetrics);
 
@@ -3516,7 +3512,7 @@ CanvasRenderingContext2DImpl::GetTransform(const v8::FunctionCallbackInfo<v8::Va
             context).ToLocalChecked();
     auto object = new MatrixImpl(matrix);
 
-    ret->SetAlignedPointerInInternalField(0, object);
+    canvas::SetAlignedPointer(ret, 0, object);
 
     SetNativeType(object, NativeType::Matrix);
 
@@ -3579,12 +3575,11 @@ CanvasRenderingContext2DImpl::StrokeText(const v8::FunctionCallbackInfo<v8::Valu
     auto count = args.Length();
     if (count >= 3 && args[0]->IsString()) {
         auto js_str = args[0].As<v8::String>();
-        const int text_utf8_len = js_str->Utf8Length(isolate);
+        const int text_utf8_len = canvas::Utf8Length(js_str, isolate);
 
         auto &scratch = g_tls_scratch;
         scratch.resize(static_cast<size_t>(text_utf8_len) + 1);
-        js_str->WriteUtf8(isolate, scratch.data(), text_utf8_len, nullptr,
-                          v8::String::NO_NULL_TERMINATION);
+        canvas::WriteUtf8(js_str, isolate, scratch.data(), text_utf8_len, false);
         scratch[text_utf8_len] = '\0';
 
         auto x = static_cast<float>(args[1]->NumberValue(context).ToChecked());

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.h
@@ -173,7 +173,7 @@ public:
         auto object = CanvasRenderingContext2DImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(renderingContext, NativeType::CanvasRenderingContext2D);
-        object->SetAlignedPointerInInternalField(0, renderingContext);
+        canvas::SetAlignedPointer(object, 0, renderingContext);
         renderingContext->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
@@ -203,167 +203,167 @@ public:
     static void __Resize(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
-    static void SetContinuousRenderMode(v8::Local<v8::String> property,
+    static void SetContinuousRenderMode(v8::Local<v8::Name> property,
                                         v8::Local<v8::Value> value,
                                         const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetContinuousRenderMode(v8::Local<v8::String> property,
+    static void GetContinuousRenderMode(v8::Local<v8::Name> property,
                                         const v8::PropertyCallbackInfo<v8::Value> &info);
 
 
-    static void GetFilter(v8::Local<v8::String> property,
+    static void GetFilter(v8::Local<v8::Name> property,
                           const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetFilter(v8::Local<v8::String> property,
+    static void SetFilter(v8::Local<v8::Name> property,
                           v8::Local<v8::Value> value,
                           const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetFont(v8::Local<v8::String> property,
+    static void GetFont(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetFont(v8::Local<v8::String> property,
+    static void SetFont(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetLetterSpacing(v8::Local<v8::String> property,
+    static void GetLetterSpacing(v8::Local<v8::Name> property,
                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLetterSpacing(v8::Local<v8::String> property,
+    static void SetLetterSpacing(v8::Local<v8::Name> property,
                                  v8::Local<v8::Value> value,
                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetWordSpacing(v8::Local<v8::String> property,
+    static void GetWordSpacing(v8::Local<v8::Name> property,
                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetWordSpacing(v8::Local<v8::String> property,
+    static void SetWordSpacing(v8::Local<v8::Name> property,
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void SetGlobalAlpha(v8::Local<v8::String> property,
+    static void SetGlobalAlpha(v8::Local<v8::Name> property,
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetGlobalAlpha(v8::Local<v8::String> property,
+    static void GetGlobalAlpha(v8::Local<v8::Name> property,
                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
 
-    static void SetImageSmoothingEnabled(v8::Local<v8::String> property,
+    static void SetImageSmoothingEnabled(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetImageSmoothingEnabled(v8::Local<v8::String> property,
+    static void GetImageSmoothingEnabled(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetImageSmoothingQuality(v8::Local<v8::String> property,
+    static void SetImageSmoothingQuality(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetImageSmoothingQuality(v8::Local<v8::String> property,
+    static void GetImageSmoothingQuality(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLineDashOffset(v8::Local<v8::String> property,
+    static void SetLineDashOffset(v8::Local<v8::Name> property,
                                   v8::Local<v8::Value> value,
                                   const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetLineDashOffset(v8::Local<v8::String> property,
+    static void GetLineDashOffset(v8::Local<v8::Name> property,
                                   const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetLineJoin(v8::Local<v8::String> property,
+    static void GetLineJoin(v8::Local<v8::Name> property,
                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLineJoin(v8::Local<v8::String> property,
+    static void SetLineJoin(v8::Local<v8::Name> property,
                             v8::Local<v8::Value> value,
                             const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetLineCap(v8::Local<v8::String> property,
+    static void GetLineCap(v8::Local<v8::Name> property,
                            const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLineCap(v8::Local<v8::String> property,
+    static void SetLineCap(v8::Local<v8::Name> property,
                            v8::Local<v8::Value> value,
                            const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMiterLimit(v8::Local<v8::String> property,
+    static void GetMiterLimit(v8::Local<v8::Name> property,
                               const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMiterLimit(v8::Local<v8::String> property,
+    static void SetMiterLimit(v8::Local<v8::Name> property,
                               v8::Local<v8::Value> value,
                               const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetShadowColor(v8::Local<v8::String> property,
+    static void GetShadowColor(v8::Local<v8::Name> property,
                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetShadowColor(v8::Local<v8::String> property,
+    static void SetShadowColor(v8::Local<v8::Name> property,
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetShadowBlur(v8::Local<v8::String> property,
+    static void GetShadowBlur(v8::Local<v8::Name> property,
                               const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetShadowBlur(v8::Local<v8::String> property,
+    static void SetShadowBlur(v8::Local<v8::Name> property,
                               v8::Local<v8::Value> value,
                               const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetShadowOffsetX(v8::Local<v8::String> property,
+    static void GetShadowOffsetX(v8::Local<v8::Name> property,
                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetShadowOffsetX(v8::Local<v8::String> property,
+    static void SetShadowOffsetX(v8::Local<v8::Name> property,
                                  v8::Local<v8::Value> value,
                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetShadowOffsetY(v8::Local<v8::String> property,
+    static void GetShadowOffsetY(v8::Local<v8::Name> property,
                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetShadowOffsetY(v8::Local<v8::String> property,
+    static void SetShadowOffsetY(v8::Local<v8::Name> property,
                                  v8::Local<v8::Value> value,
                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetTextAlign(v8::Local<v8::String> property,
+    static void GetTextAlign(v8::Local<v8::Name> property,
                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetTextAlign(v8::Local<v8::String> property,
+    static void SetTextAlign(v8::Local<v8::Name> property,
                              v8::Local<v8::Value> value,
                              const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetTextBaseline(v8::Local<v8::String> property,
+    static void GetTextBaseline(v8::Local<v8::Name> property,
                                 const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetTextBaseline(v8::Local<v8::String> property,
+    static void SetTextBaseline(v8::Local<v8::Name> property,
                                 v8::Local<v8::Value> value,
                                 const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetGlobalCompositeOperation(v8::Local<v8::String> property,
+    static void GetGlobalCompositeOperation(v8::Local<v8::Name> property,
                                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetGlobalCompositeOperation(v8::Local<v8::String> property,
+    static void SetGlobalCompositeOperation(v8::Local<v8::Name> property,
                                             v8::Local<v8::Value> value,
                                             const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetFillStyle(v8::Local<v8::String> property,
+    static void GetFillStyle(v8::Local<v8::Name> property,
                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetFillStyle(v8::Local<v8::String> property,
+    static void SetFillStyle(v8::Local<v8::Name> property,
                              v8::Local<v8::Value> value,
                              const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetStrokeStyle(v8::Local<v8::String> property,
+    static void GetStrokeStyle(v8::Local<v8::Name> property,
                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetStrokeStyle(v8::Local<v8::String> property,
+    static void SetStrokeStyle(v8::Local<v8::Name> property,
                                v8::Local<v8::Value> value,
                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetLineWidth(v8::Local<v8::String> property,
+    static void GetLineWidth(v8::Local<v8::Name> property,
                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLineWidth(v8::Local<v8::String> property,
+    static void SetLineWidth(v8::Local<v8::Name> property,
                              v8::Local<v8::Value> value,
                              const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetLineDash(v8::Local<v8::String> property,
+    static void GetLineDash(v8::Local<v8::Name> property,
                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetLineDash(v8::Local<v8::String> property,
+    static void SetLineDash(v8::Local<v8::Name> property,
                             v8::Local<v8::Value> value,
                             const v8::PropertyCallbackInfo<void> &info);
 

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/ImageDataImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/ImageDataImpl.cpp
@@ -52,7 +52,7 @@ void ImageDataImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolat
 
 
 ImageDataImpl *ImageDataImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -111,7 +111,7 @@ void ImageDataImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
         auto object = new ImageDataImpl(image_data);
 
-        ret->SetAlignedPointerInInternalField(0, object);
+        canvas::SetAlignedPointer(ret, 0, object);
 
         object->BindFinalizer(isolate, ret);
 
@@ -134,7 +134,7 @@ void ImageDataImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
         auto object = new ImageDataImpl(image_data);
 
-        ret->SetAlignedPointerInInternalField(0, object);
+        canvas::SetAlignedPointer(ret, 0, object);
 
         SetNativeType(object, NativeType::ImageData);
 
@@ -152,7 +152,7 @@ void ImageDataImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 void
 ImageDataImpl::GetWidth(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_image_data_get_width(ptr->GetImageData());
         info.GetReturnValue().Set(ret);
@@ -164,7 +164,7 @@ ImageDataImpl::GetWidth(v8::Local<v8::Name> name,
 void
 ImageDataImpl::GetHeight(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_image_data_get_height(ptr->GetImageData());
         info.GetReturnValue().Set(ret);
@@ -177,7 +177,7 @@ ImageDataImpl::GetHeight(v8::Local<v8::Name> name,
 void
 ImageDataImpl::GetData(v8::Local<v8::Name> name,
                        const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
 

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/MatrixImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/MatrixImpl.cpp
@@ -21,7 +21,7 @@ void MatrixImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate) 
 }
 
 MatrixImpl *MatrixImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -42,141 +42,141 @@ v8::Local<v8::FunctionTemplate> MatrixImpl::GetCtor(v8::Isolate *isolate) {
     auto tmpl = ctorTmpl->InstanceTemplate();
     tmpl->SetInternalFieldCount(2);
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "a"),
             GetA,
             SetA
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "b"),
             GetB,
             SetB
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "c"),
             GetC,
             SetC
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "d"),
             GetD,
             SetD
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "e"),
             GetE,
             SetE
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "f"),
             GetF,
             SetF
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m11"),
             GetM11,
             SetM11
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m12"),
             GetM12,
             SetM12
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m13"),
             GetM13,
             SetM13
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m14"),
             GetM14,
             SetM14
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m21"),
             GetM21,
             SetM21
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m22"),
             GetM22,
             SetM22
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m23"),
             GetM23,
             SetM23
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m24"),
             GetM24,
             SetM24
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m31"),
             GetM31,
             SetM31
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m32"),
             GetM32,
             SetM32
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m33"),
             GetM33,
             SetM33
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m34"),
             GetM34,
             SetM34
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m41"),
             GetM41,
             SetM41
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m42"),
             GetM42,
             SetM42
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m43"),
             GetM43,
             SetM43
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "m44"),
             GetM44,
             SetM44
@@ -279,7 +279,7 @@ void MatrixImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
                 auto object = new MatrixImpl(matrix);
 
-                ret->SetAlignedPointerInInternalField(0, object);
+                canvas::SetAlignedPointer(ret, 0, object);
 
                 SetNativeType(object, NativeType::Matrix);
 
@@ -305,7 +305,7 @@ void MatrixImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
                 auto object = new MatrixImpl(matrix);
 
 
-                ret->SetAlignedPointerInInternalField(0, object);
+                canvas::SetAlignedPointer(ret, 0, object);
 
                 SetNativeType(object, NativeType::Matrix);
 
@@ -320,7 +320,7 @@ void MatrixImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
         auto matrix = canvas_native_matrix_create();
         auto object = new MatrixImpl(matrix);
 
-        ret->SetAlignedPointerInInternalField(0, object);
+        canvas::SetAlignedPointer(ret, 0, object);
 
         SetNativeType(object, NativeType::Matrix);
 
@@ -333,9 +333,9 @@ void MatrixImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
     args.GetReturnValue().SetUndefined();
 }
 
-void MatrixImpl::GetA(v8::Local<v8::String> property,
+void MatrixImpl::GetA(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -345,10 +345,10 @@ void MatrixImpl::GetA(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetA(v8::Local<v8::String> property,
+void MatrixImpl::SetA(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -358,9 +358,9 @@ void MatrixImpl::SetA(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetB(v8::Local<v8::String> property,
+void MatrixImpl::GetB(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -370,10 +370,10 @@ void MatrixImpl::GetB(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetB(v8::Local<v8::String> property,
+void MatrixImpl::SetB(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -383,9 +383,9 @@ void MatrixImpl::SetB(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetC(v8::Local<v8::String> property,
+void MatrixImpl::GetC(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -395,10 +395,10 @@ void MatrixImpl::GetC(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetC(v8::Local<v8::String> property,
+void MatrixImpl::SetC(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -408,9 +408,9 @@ void MatrixImpl::SetC(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetD(v8::Local<v8::String> property,
+void MatrixImpl::GetD(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -420,10 +420,10 @@ void MatrixImpl::GetD(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetD(v8::Local<v8::String> property,
+void MatrixImpl::SetD(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -433,9 +433,9 @@ void MatrixImpl::SetD(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetE(v8::Local<v8::String> property,
+void MatrixImpl::GetE(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -445,10 +445,10 @@ void MatrixImpl::GetE(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetE(v8::Local<v8::String> property,
+void MatrixImpl::SetE(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -458,9 +458,9 @@ void MatrixImpl::SetE(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetF(v8::Local<v8::String> property,
+void MatrixImpl::GetF(v8::Local<v8::Name> property,
                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -470,10 +470,10 @@ void MatrixImpl::GetF(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetF(v8::Local<v8::String> property,
+void MatrixImpl::SetF(v8::Local<v8::Name> property,
                       v8::Local<v8::Value> value,
                       const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -482,9 +482,9 @@ void MatrixImpl::SetF(v8::Local<v8::String> property,
     canvas_native_matrix_set_f(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM11(v8::Local<v8::String> property,
+void MatrixImpl::GetM11(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -494,10 +494,10 @@ void MatrixImpl::GetM11(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM11(v8::Local<v8::String> property,
+void MatrixImpl::SetM11(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -506,9 +506,9 @@ void MatrixImpl::SetM11(v8::Local<v8::String> property,
     canvas_native_matrix_set_m11(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM12(v8::Local<v8::String> property,
+void MatrixImpl::GetM12(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -518,10 +518,10 @@ void MatrixImpl::GetM12(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM12(v8::Local<v8::String> property,
+void MatrixImpl::SetM12(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -530,9 +530,9 @@ void MatrixImpl::SetM12(v8::Local<v8::String> property,
     canvas_native_matrix_set_m12(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM13(v8::Local<v8::String> property,
+void MatrixImpl::GetM13(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -542,10 +542,10 @@ void MatrixImpl::GetM13(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM13(v8::Local<v8::String> property,
+void MatrixImpl::SetM13(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -554,9 +554,9 @@ void MatrixImpl::SetM13(v8::Local<v8::String> property,
     canvas_native_matrix_set_m13(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM14(v8::Local<v8::String> property,
+void MatrixImpl::GetM14(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -566,10 +566,10 @@ void MatrixImpl::GetM14(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM14(v8::Local<v8::String> property,
+void MatrixImpl::SetM14(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -578,9 +578,9 @@ void MatrixImpl::SetM14(v8::Local<v8::String> property,
     canvas_native_matrix_set_m14(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM21(v8::Local<v8::String> property,
+void MatrixImpl::GetM21(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -590,10 +590,10 @@ void MatrixImpl::GetM21(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM21(v8::Local<v8::String> property,
+void MatrixImpl::SetM21(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -602,9 +602,9 @@ void MatrixImpl::SetM21(v8::Local<v8::String> property,
     canvas_native_matrix_set_m21(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM22(v8::Local<v8::String> property,
+void MatrixImpl::GetM22(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -614,10 +614,10 @@ void MatrixImpl::GetM22(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM22(v8::Local<v8::String> property,
+void MatrixImpl::SetM22(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -626,9 +626,9 @@ void MatrixImpl::SetM22(v8::Local<v8::String> property,
     canvas_native_matrix_set_m22(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM23(v8::Local<v8::String> property,
+void MatrixImpl::GetM23(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -638,10 +638,10 @@ void MatrixImpl::GetM23(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM23(v8::Local<v8::String> property,
+void MatrixImpl::SetM23(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -650,9 +650,9 @@ void MatrixImpl::SetM23(v8::Local<v8::String> property,
     canvas_native_matrix_set_m23(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM24(v8::Local<v8::String> property,
+void MatrixImpl::GetM24(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -662,10 +662,10 @@ void MatrixImpl::GetM24(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM24(v8::Local<v8::String> property,
+void MatrixImpl::SetM24(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -675,9 +675,9 @@ void MatrixImpl::SetM24(v8::Local<v8::String> property,
 }
 
 
-void MatrixImpl::GetM31(v8::Local<v8::String> property,
+void MatrixImpl::GetM31(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -687,10 +687,10 @@ void MatrixImpl::GetM31(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM31(v8::Local<v8::String> property,
+void MatrixImpl::SetM31(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -699,9 +699,9 @@ void MatrixImpl::SetM31(v8::Local<v8::String> property,
     canvas_native_matrix_set_m31(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM32(v8::Local<v8::String> property,
+void MatrixImpl::GetM32(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -711,10 +711,10 @@ void MatrixImpl::GetM32(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM32(v8::Local<v8::String> property,
+void MatrixImpl::SetM32(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -723,9 +723,9 @@ void MatrixImpl::SetM32(v8::Local<v8::String> property,
     canvas_native_matrix_set_m32(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM33(v8::Local<v8::String> property,
+void MatrixImpl::GetM33(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -735,10 +735,10 @@ void MatrixImpl::GetM33(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM33(v8::Local<v8::String> property,
+void MatrixImpl::SetM33(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -747,9 +747,9 @@ void MatrixImpl::SetM33(v8::Local<v8::String> property,
     canvas_native_matrix_set_m33(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM34(v8::Local<v8::String> property,
+void MatrixImpl::GetM34(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -759,10 +759,10 @@ void MatrixImpl::GetM34(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM34(v8::Local<v8::String> property,
+void MatrixImpl::SetM34(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -771,9 +771,9 @@ void MatrixImpl::SetM34(v8::Local<v8::String> property,
     canvas_native_matrix_set_m34(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM41(v8::Local<v8::String> property,
+void MatrixImpl::GetM41(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -783,10 +783,10 @@ void MatrixImpl::GetM41(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM41(v8::Local<v8::String> property,
+void MatrixImpl::SetM41(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -795,9 +795,9 @@ void MatrixImpl::SetM41(v8::Local<v8::String> property,
     canvas_native_matrix_set_m41(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM42(v8::Local<v8::String> property,
+void MatrixImpl::GetM42(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -807,10 +807,10 @@ void MatrixImpl::GetM42(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM42(v8::Local<v8::String> property,
+void MatrixImpl::SetM42(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -819,9 +819,9 @@ void MatrixImpl::SetM42(v8::Local<v8::String> property,
     canvas_native_matrix_set_m42(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM43(v8::Local<v8::String> property,
+void MatrixImpl::GetM43(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -831,10 +831,10 @@ void MatrixImpl::GetM43(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM43(v8::Local<v8::String> property,
+void MatrixImpl::SetM43(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -843,9 +843,9 @@ void MatrixImpl::SetM43(v8::Local<v8::String> property,
     canvas_native_matrix_set_m43(ptr->GetMatrix(), (float) value->NumberValue(context).ToChecked());
 }
 
-void MatrixImpl::GetM44(v8::Local<v8::String> property,
+void MatrixImpl::GetM44(v8::Local<v8::Name> property,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().SetUndefined();
         return;
@@ -855,10 +855,10 @@ void MatrixImpl::GetM44(v8::Local<v8::String> property,
 
 }
 
-void MatrixImpl::SetM44(v8::Local<v8::String> property,
+void MatrixImpl::SetM44(v8::Local<v8::Name> property,
                         v8::Local<v8::Value> value,
                         const v8::PropertyCallbackInfo<void> &info) {
-    MatrixImpl *ptr = GetPointer(info.This());
+    MatrixImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -895,7 +895,7 @@ void MatrixImpl::Translate(const v8::FunctionCallbackInfo<v8::Value> &args) {
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
             auto object = new MatrixImpl(matrix);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             SetNativeType(object, NativeType::Matrix);
 
@@ -987,7 +987,7 @@ void MatrixImpl::ScaleNonUniform(const v8::FunctionCallbackInfo<v8::Value> &args
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
             auto object = new MatrixImpl(matrix);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             SetNativeType(object, NativeType::Matrix);
 
@@ -1046,7 +1046,7 @@ void MatrixImpl::Rotate(const v8::FunctionCallbackInfo<v8::Value> &args) {
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
             auto object = new MatrixImpl(matrix);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             SetNativeType(object, NativeType::Matrix);
 
@@ -1103,7 +1103,7 @@ void MatrixImpl::SkewX(const v8::FunctionCallbackInfo<v8::Value> &args) {
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
             auto object = new MatrixImpl(matrix);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             SetNativeType(object, NativeType::Matrix);
 
@@ -1156,7 +1156,7 @@ void MatrixImpl::SkewY(const v8::FunctionCallbackInfo<v8::Value> &args) {
                     context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
             auto object = new MatrixImpl(matrix);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             SetNativeType(object, NativeType::Matrix);
 
@@ -1196,7 +1196,7 @@ void MatrixImpl::Clone(const v8::FunctionCallbackInfo<v8::Value> &args) {
             context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
     auto object = new MatrixImpl(matrix);
 
-    ret->SetAlignedPointerInInternalField(0, object);
+    canvas::SetAlignedPointer(ret, 0, object);
 
     SetNativeType(object, NativeType::Matrix);
 

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/MatrixImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/MatrixImpl.h
@@ -26,161 +26,161 @@ public:
 
     static void Ctor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    static void GetA(v8::Local<v8::String> property,
+    static void GetA(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetA(v8::Local<v8::String> property,
+    static void SetA(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetB(v8::Local<v8::String> property,
+    static void GetB(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetB(v8::Local<v8::String> property,
+    static void SetB(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetC(v8::Local<v8::String> property,
+    static void GetC(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetC(v8::Local<v8::String> property,
+    static void SetC(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetD(v8::Local<v8::String> property,
+    static void GetD(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetD(v8::Local<v8::String> property,
+    static void SetD(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetE(v8::Local<v8::String> property,
+    static void GetE(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetE(v8::Local<v8::String> property,
+    static void SetE(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetF(v8::Local<v8::String> property,
+    static void GetF(v8::Local<v8::Name> property,
                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetF(v8::Local<v8::String> property,
-                     v8::Local<v8::Value> value,
-                     const v8::PropertyCallbackInfo<void> &info);
-
-
-    static void GetM11(v8::Local<v8::String> property,
-                     const v8::PropertyCallbackInfo<v8::Value> &info);
-
-    static void SetM11(v8::Local<v8::String> property,
+    static void SetF(v8::Local<v8::Name> property,
                      v8::Local<v8::Value> value,
                      const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetM12(v8::Local<v8::String> property,
+    static void GetM11(v8::Local<v8::Name> property,
+                     const v8::PropertyCallbackInfo<v8::Value> &info);
+
+    static void SetM11(v8::Local<v8::Name> property,
+                     v8::Local<v8::Value> value,
+                     const v8::PropertyCallbackInfo<void> &info);
+
+
+    static void GetM12(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM12(v8::Local<v8::String> property,
+    static void SetM12(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetM13(v8::Local<v8::String> property,
+    static void GetM13(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM13(v8::Local<v8::String> property,
+    static void SetM13(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM14(v8::Local<v8::String> property,
+    static void GetM14(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM14(v8::Local<v8::String> property,
+    static void SetM14(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM21(v8::Local<v8::String> property,
+    static void GetM21(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM21(v8::Local<v8::String> property,
+    static void SetM21(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM22(v8::Local<v8::String> property,
+    static void GetM22(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM22(v8::Local<v8::String> property,
+    static void SetM22(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM23(v8::Local<v8::String> property,
+    static void GetM23(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM23(v8::Local<v8::String> property,
+    static void SetM23(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM24(v8::Local<v8::String> property,
+    static void GetM24(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM24(v8::Local<v8::String> property,
+    static void SetM24(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM31(v8::Local<v8::String> property,
+    static void GetM31(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM31(v8::Local<v8::String> property,
+    static void SetM31(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM32(v8::Local<v8::String> property,
+    static void GetM32(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM32(v8::Local<v8::String> property,
+    static void SetM32(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM33(v8::Local<v8::String> property,
+    static void GetM33(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM33(v8::Local<v8::String> property,
+    static void SetM33(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM34(v8::Local<v8::String> property,
+    static void GetM34(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM34(v8::Local<v8::String> property,
+    static void SetM34(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM41(v8::Local<v8::String> property,
+    static void GetM41(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM41(v8::Local<v8::String> property,
+    static void SetM41(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM42(v8::Local<v8::String> property,
+    static void GetM42(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM42(v8::Local<v8::String> property,
+    static void SetM42(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM43(v8::Local<v8::String> property,
+    static void GetM43(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM43(v8::Local<v8::String> property,
+    static void SetM43(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetM44(v8::Local<v8::String> property,
+    static void GetM44(v8::Local<v8::Name> property,
                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetM44(v8::Local<v8::String> property,
+    static void SetM44(v8::Local<v8::Name> property,
                        v8::Local<v8::Value> value,
                        const v8::PropertyCallbackInfo<void> &info);
 

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/Path2D.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/Path2D.cpp
@@ -24,49 +24,49 @@ void Path2D::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate) {
 }
 
 Path2D *Path2D::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
     return static_cast<Path2D *>(ptr);
 }
 
-v8::CFunction Path2D::fast_arc_(v8::CFunction::Make(Path2D::FastArc));
+v8::CFunction Path2D::fast_arc_(CANVAS_FAST_FUNCTION(Path2D::FastArc));
 
-v8::CFunction Path2D::fast_add_path_(v8::CFunction::Make(Path2D::FastAddPath));
+v8::CFunction Path2D::fast_add_path_(CANVAS_FAST_FUNCTION(Path2D::FastAddPath));
 
-v8::CFunction Path2D::fast_arc_to_(v8::CFunction::Make(Path2D::FastArcTo));
+v8::CFunction Path2D::fast_arc_to_(CANVAS_FAST_FUNCTION(Path2D::FastArcTo));
 
-v8::CFunction Path2D::fast_bezier_curve_to_(v8::CFunction::Make(Path2D::FastBezierCurveTo));
+v8::CFunction Path2D::fast_bezier_curve_to_(CANVAS_FAST_FUNCTION(Path2D::FastBezierCurveTo));
 
-v8::CFunction Path2D::fast_close_path_(v8::CFunction::Make(Path2D::FastClosePath));
+v8::CFunction Path2D::fast_close_path_(CANVAS_FAST_FUNCTION(Path2D::FastClosePath));
 
-v8::CFunction Path2D::fast_ellipse_(v8::CFunction::Make(Path2D::FastEllipse));
+v8::CFunction Path2D::fast_ellipse_(CANVAS_FAST_FUNCTION(Path2D::FastEllipse));
 
-v8::CFunction Path2D::fast_line_to_(v8::CFunction::Make(Path2D::FastLineTo));
+v8::CFunction Path2D::fast_line_to_(CANVAS_FAST_FUNCTION(Path2D::FastLineTo));
 
-v8::CFunction Path2D::fast_move_to_(v8::CFunction::Make(Path2D::FastMoveTo));
+v8::CFunction Path2D::fast_move_to_(CANVAS_FAST_FUNCTION(Path2D::FastMoveTo));
 
-v8::CFunction Path2D::fast_quadratic_curve_to_(v8::CFunction::Make(Path2D::FastQuadraticCurveTo));
+v8::CFunction Path2D::fast_quadratic_curve_to_(CANVAS_FAST_FUNCTION(Path2D::FastQuadraticCurveTo));
 
-v8::CFunction Path2D::fast_rect_(v8::CFunction::Make(Path2D::FastRect));
+v8::CFunction Path2D::fast_rect_(CANVAS_FAST_FUNCTION(Path2D::FastRect));
 
 v8::CFunction Path2D::fast_round_rect_(
-        v8::CFunction::Make(Path2D::FastRoundRect));
+        CANVAS_FAST_FUNCTION(Path2D::FastRoundRect));
 
 v8::CFunction Path2D::fast_round_rect_array_(
-        v8::CFunction::Make(Path2D::FastRoundRectArray));
+        CANVAS_FAST_FUNCTION(Path2D::FastRoundRectArray));
 
 const v8::CFunction fast_round_rect_overloads_[] = {
         Path2D::fast_round_rect_,
         Path2D::fast_round_rect_array_
 };
 
-v8::CFunction Path2D::fast_trim_(v8::CFunction::Make(Path2D::FastTrim));
+v8::CFunction Path2D::fast_trim_(CANVAS_FAST_FUNCTION(Path2D::FastTrim));
 
 
 
-//v8::CFunction Path2D::fast_to_svg_(v8::CFunction::Make(Path2D::FastToSVG));
+//v8::CFunction Path2D::fast_to_svg_(CANVAS_FAST_FUNCTION(Path2D::FastToSVG));
 
 void Path2D::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
     auto count = args.Length();
@@ -81,7 +81,7 @@ void Path2D::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
             auto path = canvas_native_path_create_with_string(d.c_str());
             auto object = new Path2D(path);
 
-            ret->SetAlignedPointerInInternalField(0, object);
+            canvas::SetAlignedPointer(ret, 0, object);
 
             object->BindFinalizer(isolate, ret);
 
@@ -98,7 +98,7 @@ void Path2D::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
                         path_to_copy->GetPath());
                 auto object = new Path2D(path);
 
-                ret->SetAlignedPointerInInternalField(0, object);
+                canvas::SetAlignedPointer(ret, 0, object);
 
                 object->BindFinalizer(isolate, ret);
 
@@ -111,7 +111,7 @@ void Path2D::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
     } else {
         auto path = new Path2D(canvas_native_path_create());
 
-        ret->SetAlignedPointerInInternalField(0, path);
+        canvas::SetAlignedPointer(ret, 0, path);
 
         path->BindFinalizer(isolate, ret);
 

--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/TextMetricsImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/TextMetricsImpl.cpp
@@ -24,7 +24,7 @@ void TextMetricsImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isol
 }
 
 TextMetricsImpl *TextMetricsImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -66,7 +66,7 @@ v8::Local<v8::FunctionTemplate> TextMetricsImpl::GetCtor(v8::Isolate *isolate) {
 #define TM_GETTER(FnName, field)                                                        \
 void TextMetricsImpl::FnName(v8::Local<v8::Name> property,                             \
                              const v8::PropertyCallbackInfo<v8::Value> &info) {         \
-    TextMetricsImpl *ptr = GetPointer(info.This());                                     \
+    TextMetricsImpl *ptr = GetPointer(canvas::Receiver(info));                                     \
     if (ptr == nullptr) { info.GetReturnValue().Set(0); return; }                       \
     info.GetReturnValue().Set((double) ptr->data_.field);                               \
 }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLActiveInfoImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLActiveInfoImpl.cpp
@@ -9,7 +9,7 @@
 WebGLActiveInfoImpl::WebGLActiveInfoImpl(WebGLActiveInfo* info) : info_(info) {}
 
 WebGLActiveInfoImpl *WebGLActiveInfoImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -47,7 +47,7 @@ v8::Local<v8::FunctionTemplate> WebGLActiveInfoImpl::GetCtor(v8::Isolate *isolat
 void
 WebGLActiveInfoImpl::GetName(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto info_name = canvas_native_webgl_active_info_get_name(ptr->GetWebGLActiveInfo());
@@ -62,7 +62,7 @@ WebGLActiveInfoImpl::GetName(v8::Local<v8::Name> name,
 void
 WebGLActiveInfoImpl::GetSize(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto size = canvas_native_webgl_active_info_get_size(ptr->GetWebGLActiveInfo());
         info.GetReturnValue().Set(size);
@@ -75,7 +75,7 @@ WebGLActiveInfoImpl::GetSize(v8::Local<v8::Name> name,
 void
 WebGLActiveInfoImpl::GetType(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto type = canvas_native_webgl_active_info_get_type(ptr->GetWebGLActiveInfo());
         info.GetReturnValue().Set(type);

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLActiveInfoImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLActiveInfoImpl.h
@@ -26,7 +26,7 @@ public:
         auto object = WebGLActiveInfoImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( info, NativeType::WebGLActiveInfo);
-        object->SetAlignedPointerInInternalField(0, info);
+        canvas::SetAlignedPointer(object, 0, info);
         info->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLBuffer.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLBuffer.h
@@ -36,13 +36,13 @@ public:
         auto object = WebGLBuffer::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( buffer, NativeType::WebGLBuffer);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         buffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLBuffer *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLFramebuffer.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLFramebuffer.h
@@ -36,13 +36,13 @@ public:
         auto object = WebGLFramebuffer::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( buffer, NativeType::WebGLFramebuffer);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         buffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLFramebuffer *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLProgram.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLProgram.h
@@ -40,13 +40,13 @@ public:
         auto object = WebGLProgram::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( program, NativeType::WebGLProgram);
-        object->SetAlignedPointerInInternalField(0, program);
+        canvas::SetAlignedPointer(object, 0, program);
         program->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLProgram *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderbuffer.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderbuffer.h
@@ -35,13 +35,13 @@ public:
         auto object = WebGLRenderbuffer::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( buffer, NativeType::WebGLRenderbuffer);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         buffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLRenderbuffer *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContext.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContext.cpp
@@ -6,30 +6,30 @@
 #include "OneByteStringResource.h"
 
 v8::CFunction WebGLRenderingContext::fast_disable_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDisable));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDisable));
 
 v8::CFunction WebGLRenderingContext::fast_resized_(
-        v8::CFunction::Make(WebGLRenderingContext::__FastResized));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::__FastResized));
 
 v8::CFunction WebGLRenderingContext::fast_start_raf_(
-        v8::CFunction::Make(WebGLRenderingContext::__FastStartRaf));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::__FastStartRaf));
 
 v8::CFunction WebGLRenderingContext::fast_stop_raf_(
-        v8::CFunction::Make(WebGLRenderingContext::__FastStopRaf));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::__FastStopRaf));
 
 v8::CFunction WebGLRenderingContext::fast_active_texture_(
-        v8::CFunction::Make(WebGLRenderingContext::FastActiveTexture));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastActiveTexture));
 
 
 v8::CFunction WebGLRenderingContext::fast_attach_shader_(
-        v8::CFunction::Make(WebGLRenderingContext::FastAttachShader));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastAttachShader));
 
 
 v8::CFunction WebGLRenderingContext::fast_bind_buffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindBuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindBuffer));
 
 v8::CFunction WebGLRenderingContext::fast_bind_buffer_null_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindBufferNull));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindBufferNull));
 
 const v8::CFunction bind_buffer_overloads_[] = {
         WebGLRenderingContext::fast_bind_buffer_,
@@ -38,60 +38,60 @@ const v8::CFunction bind_buffer_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform1f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1f));
 
 v8::CFunction WebGLRenderingContext::fast_uniform1i_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1i));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1i));
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform2f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2f));
 
 v8::CFunction WebGLRenderingContext::fast_uniform2i_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2i));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2i));
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform3f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3f));
 
 v8::CFunction WebGLRenderingContext::fast_uniform3i_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3i));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3i));
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform4f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4f));
 
 v8::CFunction WebGLRenderingContext::fast_uniform4i_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4i));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4i));
 
 
 v8::CFunction WebGLRenderingContext::fast_draw_arrays_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDrawArrays));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDrawArrays));
 
 v8::CFunction WebGLRenderingContext::fast_clear_depth_(
-        v8::CFunction::Make(WebGLRenderingContext::FastClearDepth));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastClearDepth));
 
 v8::CFunction WebGLRenderingContext::fast_clear_stencil_(
-        v8::CFunction::Make(WebGLRenderingContext::FastClearStencil));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastClearStencil));
 
 v8::CFunction WebGLRenderingContext::fast_clear_(
-        v8::CFunction::Make(WebGLRenderingContext::FastClear));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastClear));
 
 v8::CFunction WebGLRenderingContext::fast_clear_color_(
-        v8::CFunction::Make(WebGLRenderingContext::FastClearColor));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastClearColor));
 
 v8::CFunction WebGLRenderingContext::fast_enable_(
-        v8::CFunction::Make(WebGLRenderingContext::FastEnable));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastEnable));
 
 v8::CFunction WebGLRenderingContext::fast_enable_vertex_attrib_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastEnableVertexAttribArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastEnableVertexAttribArray));
 
 
 v8::CFunction WebGLRenderingContext::fast_use_program_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUseProgram));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUseProgram));
 
 v8::CFunction WebGLRenderingContext::fast_use_program_null_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUseProgramNull));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUseProgramNull));
 
 
 const v8::CFunction fast_use_overloads_[] = {
@@ -101,14 +101,14 @@ const v8::CFunction fast_use_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_viewport_(
-        v8::CFunction::Make(WebGLRenderingContext::FastViewport));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastViewport));
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix2fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix2fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix2fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix2fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix2fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix2fvArray));
 
 const v8::CFunction uniform_matrix2fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_matrix2fv_,
@@ -116,10 +116,10 @@ const v8::CFunction uniform_matrix2fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix3fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix3fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix3fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix3fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix3fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix3fvArray));
 
 const v8::CFunction uniform_matrix3fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_matrix3fv_,
@@ -127,10 +127,10 @@ const v8::CFunction uniform_matrix3fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix4fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix4fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix4fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_matrix4fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniformMatrix4fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniformMatrix4fvArray));
 
 const v8::CFunction uniform_matrix4fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_matrix4fv_,
@@ -138,10 +138,10 @@ const v8::CFunction uniform_matrix4fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_1iv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1iv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1iv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_1iv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1ivArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1ivArray));
 
 
 const v8::CFunction uniform_1iv_overloads_[] = {
@@ -150,10 +150,10 @@ const v8::CFunction uniform_1iv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_2iv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2iv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2iv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_2iv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2ivArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2ivArray));
 
 const v8::CFunction uniform_2iv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_2iv_,
@@ -161,10 +161,10 @@ const v8::CFunction uniform_2iv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_3iv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3iv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3iv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_3iv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3ivArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3ivArray));
 
 const v8::CFunction uniform_3iv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_3iv_,
@@ -172,10 +172,10 @@ const v8::CFunction uniform_3iv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_4iv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4iv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4iv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_4iv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4ivArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4ivArray));
 
 const v8::CFunction uniform_4iv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_4iv_,
@@ -184,10 +184,10 @@ const v8::CFunction uniform_4iv_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_uniform_1fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_1fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform1fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform1fvArray));
 
 const v8::CFunction uniform_1fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_1fv_,
@@ -195,10 +195,10 @@ const v8::CFunction uniform_1fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_2fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_2fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform2fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform2fvArray));
 
 const v8::CFunction uniform_2fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_2fv_,
@@ -206,10 +206,10 @@ const v8::CFunction uniform_2fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_3fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_3fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform3fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform3fvArray));
 
 const v8::CFunction uniform_3fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_3fv_,
@@ -217,10 +217,10 @@ const v8::CFunction uniform_3fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_uniform_4fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4fv));
 
 v8::CFunction WebGLRenderingContext::fast_uniform_4fv_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastUniform4fvArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastUniform4fvArray));
 
 const v8::CFunction uniform_4fv_overloads_[] = {
         WebGLRenderingContext::fast_uniform_4fv_,
@@ -228,14 +228,14 @@ const v8::CFunction uniform_4fv_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_pointer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttribPointer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttribPointer));
 
 
 v8::CFunction WebGLRenderingContext::fast_bind_frame_buffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindFramebuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindFramebuffer));
 
 v8::CFunction WebGLRenderingContext::fast_bind_frame_buffer_null_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindFramebufferNull));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindFramebufferNull));
 
 const v8::CFunction fast_bind_frame_buffer_overloads_[] = {
         WebGLRenderingContext::fast_bind_frame_buffer_null_,
@@ -244,10 +244,10 @@ const v8::CFunction fast_bind_frame_buffer_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_bind_render_buffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindRenderbuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindRenderbuffer));
 
 v8::CFunction WebGLRenderingContext::fast_bind_render_buffer_null_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindRenderbufferNull));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindRenderbufferNull));
 
 const v8::CFunction fast_bind_render_buffer_overloads_[] = {
         WebGLRenderingContext::fast_bind_render_buffer_null_,
@@ -256,10 +256,10 @@ const v8::CFunction fast_bind_render_buffer_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_bind_texture_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindTexture));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindTexture));
 
 v8::CFunction WebGLRenderingContext::fast_bind_texture_null_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBindTextureNull));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBindTextureNull));
 
 const v8::CFunction fast_bind_texture_overloads_[] = {
         WebGLRenderingContext::fast_bind_texture_null_,
@@ -267,88 +267,88 @@ const v8::CFunction fast_bind_texture_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_draw_elements_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDrawElements));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDrawElements));
 
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_1f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib1f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib1f));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_1fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib1fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib1fv));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_2f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib2f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib2f));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_2fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib2fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib2fv));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_3f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib3f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib3f));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_3fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib3fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib3fv));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_4f_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib4f));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib4f));
 
 v8::CFunction WebGLRenderingContext::fast_vertex_attrib_4fv_(
-        v8::CFunction::Make(WebGLRenderingContext::FastVertexAttrib4fv));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastVertexAttrib4fv));
 
 
 v8::CFunction WebGLRenderingContext::fast_blend_color_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBlendColor));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBlendColor));
 
 v8::CFunction WebGLRenderingContext::fast_blend_equation_separate_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBlendEquationSeparate));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBlendEquationSeparate));
 
 v8::CFunction WebGLRenderingContext::fast_blend_equation_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBlendEquation));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBlendEquation));
 
 v8::CFunction WebGLRenderingContext::fast_blend_func_separate_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBlendFuncSeparate));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBlendFuncSeparate));
 
 v8::CFunction WebGLRenderingContext::fast_blend_func_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBlendFunc));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBlendFunc));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_os_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataOS));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataOS));
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_target_usage_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataTargetUsage));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataTargetUsage));
 
 
 /*
  v8::CFunction WebGLRenderingContext::fast_buffer_data_u8_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataU8));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataU8));
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_i8_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataI8));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataI8));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_u16_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataU16));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataU16));
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_i16_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataI16));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataI16));
 */
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_u32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataU32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataU32));
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_i32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataI32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataI32));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_f32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataF32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataF32));
 
 v8::CFunction WebGLRenderingContext::fast_buffer_data_f64_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataF64));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataF64));
 //
 //v8::CFunction WebGLRenderingContext::fast_buffer_data_array_buffer_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferDataArrayBuffer));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferDataArrayBuffer));
 
 
 const v8::CFunction fast_buffer_data_overloads_[] = {
@@ -367,41 +367,41 @@ const v8::CFunction fast_buffer_data_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_target_offset_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataTargetOffset));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataTargetOffset));
 
 //v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_u8_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataU8));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataU8));
 
 
 //v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_i8_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataI8));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataI8));
 //
 //v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_u16_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataU16));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataU16));
 //
 //
 //v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_i16_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataI16));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataI16));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_u32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataU32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataU32));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_i32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataI32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataI32));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_f32_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataF32));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataF32));
 
 
 v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_f64_(
-        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataF64));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataF64));
 
 
 //v8::CFunction WebGLRenderingContext::fast_buffer_sub_data_array_buffer_(
-//        v8::CFunction::Make(WebGLRenderingContext::FastBufferSubDataArrayBuffer));
+//        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastBufferSubDataArrayBuffer));
 
 
 
@@ -417,125 +417,125 @@ const v8::CFunction fast_buffer_sub_data_overloads_[] = {
 
 
 v8::CFunction WebGLRenderingContext::fast_check_framebuffer_status_(
-        v8::CFunction::Make(WebGLRenderingContext::FastCheckFramebufferStatus));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastCheckFramebufferStatus));
 
 v8::CFunction WebGLRenderingContext::fast_validate_program_(
-        v8::CFunction::Make(WebGLRenderingContext::FastValidateProgram));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastValidateProgram));
 
 
 v8::CFunction WebGLRenderingContext::fast_delete_buffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteBuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteBuffer));
 
 
 v8::CFunction WebGLRenderingContext::fast_delete_buffer_framebuffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteFramebuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteFramebuffer));
 
 v8::CFunction WebGLRenderingContext::fast_delete_program_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteProgram));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteProgram));
 
 
 v8::CFunction WebGLRenderingContext::fast_delete_renderbuffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteRenderbuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteRenderbuffer));
 
 v8::CFunction WebGLRenderingContext::fast_delete_shader_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteShader));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteShader));
 
 v8::CFunction WebGLRenderingContext::fast_delete_texture_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDeleteTexture));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDeleteTexture));
 
 
 v8::CFunction WebGLRenderingContext::fast_compile_shader_(
-        v8::CFunction::Make(WebGLRenderingContext::FastCompileShader));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastCompileShader));
 
 v8::CFunction WebGLRenderingContext::fast_framebuffer_texture_2d_(
-        v8::CFunction::Make(WebGLRenderingContext::FastFramebufferTexture2D));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastFramebufferTexture2D));
 
 v8::CFunction WebGLRenderingContext::fast_color_mask_(
-        v8::CFunction::Make(WebGLRenderingContext::FastColorMask));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastColorMask));
 
 v8::CFunction WebGLRenderingContext::fast_copy_tex_image_2d_(
-        v8::CFunction::Make(WebGLRenderingContext::FastCopyTexImage2D));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastCopyTexImage2D));
 
 v8::CFunction WebGLRenderingContext::fast_copy_tex_sub_image_2d_(
-        v8::CFunction::Make(WebGLRenderingContext::FastCopyTexSubImage2D));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastCopyTexSubImage2D));
 
 v8::CFunction WebGLRenderingContext::fast_cull_face_(
-        v8::CFunction::Make(WebGLRenderingContext::FastCullFace));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastCullFace));
 
 v8::CFunction WebGLRenderingContext::fast_depth_func_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDepthFunc));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDepthFunc));
 
 v8::CFunction WebGLRenderingContext::fast_depth_mask_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDepthMask));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDepthMask));
 
 v8::CFunction WebGLRenderingContext::fast_depth_range_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDepthRange));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDepthRange));
 
 v8::CFunction WebGLRenderingContext::fast_detach_shader_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDetachShader));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDetachShader));
 
 v8::CFunction WebGLRenderingContext::fast_disable_vertex_attrib_array_(
-        v8::CFunction::Make(WebGLRenderingContext::FastDisableVertexAttribArray));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastDisableVertexAttribArray));
 
 v8::CFunction WebGLRenderingContext::fast_finish_(
-        v8::CFunction::Make(WebGLRenderingContext::FastFinish));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastFinish));
 
 v8::CFunction WebGLRenderingContext::fast_flush_(
-        v8::CFunction::Make(WebGLRenderingContext::FastFlush));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastFlush));
 
 v8::CFunction WebGLRenderingContext::fast_framebuffer_renderbuffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastFramebufferRenderbuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastFramebufferRenderbuffer));
 
 
 v8::CFunction WebGLRenderingContext::fast_front_face_(
-        v8::CFunction::Make(WebGLRenderingContext::FastFrontFace));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastFrontFace));
 
 v8::CFunction WebGLRenderingContext::fast_generate_mipmap_(
-        v8::CFunction::Make(WebGLRenderingContext::FastGenerateMipmap));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastGenerateMipmap));
 
 
 v8::CFunction WebGLRenderingContext::fast_get_vertex_attrib_offset_(
-        v8::CFunction::Make(WebGLRenderingContext::FastGetVertexAttribOffset));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastGetVertexAttribOffset));
 
 v8::CFunction WebGLRenderingContext::fast_hint_(
-        v8::CFunction::Make(WebGLRenderingContext::FastHint));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastHint));
 
 v8::CFunction WebGLRenderingContext::fast_is_buffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsBuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsBuffer));
 
 v8::CFunction WebGLRenderingContext::fast_is_context_lost_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsContextLost));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsContextLost));
 
 v8::CFunction WebGLRenderingContext::fast_is_enabled_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsEnabled));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsEnabled));
 
 v8::CFunction WebGLRenderingContext::fast_is_framebuffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsFramebuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsFramebuffer));
 
 v8::CFunction WebGLRenderingContext::fast_is_program_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsProgram));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsProgram));
 
 v8::CFunction WebGLRenderingContext::fast_is_renderbuffer_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsRenderbuffer));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsRenderbuffer));
 
 v8::CFunction WebGLRenderingContext::fast_is_shader_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsShader));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsShader));
 
 v8::CFunction WebGLRenderingContext::fast_is_texture_(
-        v8::CFunction::Make(WebGLRenderingContext::FastIsTexture));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastIsTexture));
 
 v8::CFunction WebGLRenderingContext::fast_line_width_(
-        v8::CFunction::Make(WebGLRenderingContext::FastLineWidth));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastLineWidth));
 
 v8::CFunction WebGLRenderingContext::fast_link_program_(
-        v8::CFunction::Make(WebGLRenderingContext::FastLinkProgram));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastLinkProgram));
 
 v8::CFunction WebGLRenderingContext::fast_pixel_storei_bool_(
-        v8::CFunction::Make(WebGLRenderingContext::FastPixelStoreiBool));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastPixelStoreiBool));
 
 
 v8::CFunction WebGLRenderingContext::fast_pixel_storei_(
-        v8::CFunction::Make(WebGLRenderingContext::FastPixelStorei));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastPixelStorei));
 
 
 const v8::CFunction fast_pixel_storei_overloads_[] = {
@@ -544,41 +544,41 @@ const v8::CFunction fast_pixel_storei_overloads_[] = {
 };
 
 v8::CFunction WebGLRenderingContext::fast_polygon_offset_(
-        v8::CFunction::Make(WebGLRenderingContext::FastPolygonOffset));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastPolygonOffset));
 
 v8::CFunction WebGLRenderingContext::fast_renderbuffer_storage_(
-        v8::CFunction::Make(WebGLRenderingContext::FastRenderbufferStorage));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastRenderbufferStorage));
 
 v8::CFunction WebGLRenderingContext::fast_sample_coverage_(
-        v8::CFunction::Make(WebGLRenderingContext::FastSampleCoverage));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastSampleCoverage));
 
 v8::CFunction WebGLRenderingContext::fast_scissor_(
-        v8::CFunction::Make(WebGLRenderingContext::FastScissor));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastScissor));
 
 
 v8::CFunction WebGLRenderingContext::fast_stencil_func_separate_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilFuncSeparate));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilFuncSeparate));
 
 v8::CFunction WebGLRenderingContext::fast_stencil_func_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilFunc));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilFunc));
 
 v8::CFunction WebGLRenderingContext::fast_stencil_mask_separate_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilMaskSeparate));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilMaskSeparate));
 
 v8::CFunction WebGLRenderingContext::fast_stencil_mask_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilMask));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilMask));
 
 v8::CFunction WebGLRenderingContext::fast_stencil_op_separate_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilOpSeparate));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilOpSeparate));
 
 v8::CFunction WebGLRenderingContext::fast_stencil_op_(
-        v8::CFunction::Make(WebGLRenderingContext::FastStencilOp));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastStencilOp));
 
 v8::CFunction WebGLRenderingContext::fast_tex_parameterf_(
-        v8::CFunction::Make(WebGLRenderingContext::FastTexParameterf));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastTexParameterf));
 
 v8::CFunction WebGLRenderingContext::fast_tex_parameteri_(
-        v8::CFunction::Make(WebGLRenderingContext::FastTexParameteri));
+        CANVAS_FAST_FUNCTION(WebGLRenderingContext::FastTexParameteri));
 
 
 WebGLRenderingContext::WebGLRenderingContext(WebGLState *state)
@@ -617,7 +617,7 @@ v8::Local<v8::FunctionTemplate> WebGLRenderingContext::GetCtor(v8::Isolate *isol
 }
 
 WebGLRenderingContext *WebGLRenderingContext::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -808,9 +808,9 @@ v8::Local<v8::Value> WebGLRenderingContext::GetParameterInternal(v8::Isolate *is
 
 
 void
-WebGLRenderingContext::GetDrawingBufferWidth(v8::Local<v8::String> name,
+WebGLRenderingContext::GetDrawingBufferWidth(v8::Local<v8::Name> name,
                                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_webgl_state_get_drawing_buffer_width(ptr->GetState());
         info.GetReturnValue().Set(ret);
@@ -820,10 +820,10 @@ WebGLRenderingContext::GetDrawingBufferWidth(v8::Local<v8::String> name,
 }
 
 
-void WebGLRenderingContext::GetDrawingBufferHeight(v8::Local<v8::String> name,
+void WebGLRenderingContext::GetDrawingBufferHeight(v8::Local<v8::Name> name,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info
 ) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_webgl_state_get_drawing_buffer_height(ptr->GetState());
         info.GetReturnValue().Set(ret);
@@ -833,9 +833,9 @@ void WebGLRenderingContext::GetDrawingBufferHeight(v8::Local<v8::String> name,
 }
 
 void
-WebGLRenderingContext::GetFlipY(v8::Local<v8::String> name,
+WebGLRenderingContext::GetFlipY(v8::Local<v8::Name> name,
                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto ret = canvas_native_webgl_state_get_flip_y(ptr->GetState());
         info.GetReturnValue().Set(ret);
@@ -6370,9 +6370,9 @@ void WebGLRenderingContext::SetConstants(v8::Isolate *isolate,
 void WebGLRenderingContext::SetProps(v8::Isolate *isolate,
                                      const v8::Local<v8::ObjectTemplate> &tmpl) {
 
-    tmpl->SetAccessor(ConvertToV8String(isolate, "drawingBufferWidth"), &GetDrawingBufferWidth);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "drawingBufferHeight"), &GetDrawingBufferHeight);
-    tmpl->SetAccessor(ConvertToV8String(isolate, "__flipY"), &GetFlipY);
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "drawingBufferWidth"), &GetDrawingBufferWidth);
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "drawingBufferHeight"), &GetDrawingBufferHeight);
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "__flipY"), &GetFlipY);
 }
 
 
@@ -6390,7 +6390,7 @@ WebGLRenderingContext::SetMethods(v8::Isolate *isolate, const v8::Local<v8::Obje
                   v8::Local<v8::Value>());
 
 
-    tmpl->SetAccessor(ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
+    canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
                       SetContinuousRenderMode);
 
 

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContext.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContext.h
@@ -302,7 +302,7 @@ public:
         auto object = WebGLRenderingContext::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(renderingContext, NativeType::WebGLRenderingContextBase);
-        object->SetAlignedPointerInInternalField(0, renderingContext);
+        canvas::SetAlignedPointer(object, 0, renderingContext);
         renderingContext->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
@@ -322,17 +322,18 @@ public:
     v8::Local<v8::Value> GetParameterInternal(v8::Isolate *isolate, uint32_t pnameValue,
                                               WebGLResult *result);
 
-    static void GetDrawingBufferWidth(v8::Local<v8::String> name,
+    static void GetDrawingBufferWidth(v8::Local<v8::Name> name,
                                       const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetFlipY(v8::Local<v8::String> name,
+    static void GetFlipY(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void GetDrawingBufferHeight(v8::Local<v8::String> name,
+    static void GetDrawingBufferHeight(v8::Local<v8::Name> name,
                                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
     static void __Resized(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void __FastResized(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -343,9 +344,11 @@ public:
                 ptr->GetState());
 
     }
+#endif
 
     static void __StartRaf(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void __FastStartRaf(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -355,9 +358,11 @@ public:
         ptr->StartRaf();
 
     }
+#endif
 
     static void __StopRaf(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void __FastStopRaf(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -367,10 +372,12 @@ public:
         ptr->StopRaf();
 
     }
+#endif
 
     static void ActiveTexture(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void FastActiveTexture(v8::Local<v8::Object> receiver_obj, uint32_t texture) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -379,6 +386,7 @@ public:
         canvas_native_webgl_active_texture(texture,
                                            ptr->GetState());
     }
+#endif
 
 
     static void AttachShader(const v8::FunctionCallbackInfo<v8::Value> &args);
@@ -396,6 +404,7 @@ public:
         );
     }
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastAttachShader(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj,
                      v8::Local<v8::Object> shader_obj) {
@@ -423,12 +432,14 @@ public:
                 shader
         );
     }
+#endif
 
     static void BindAttribLocation(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
     // todo with fast string
     /*
+#if V8_MAJOR_VERSION < 14
     static void FastBindAttribLocation(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj, uint32_t index) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -450,9 +461,12 @@ public:
 
         }
     }
+#endif
+
 */
     static void BindBuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindBuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                v8::Local<v8::Object> buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -472,7 +486,9 @@ public:
             );
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBindBufferNull(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -486,9 +502,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BindFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindFramebuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                     v8::Local<v8::Object> buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -506,7 +524,9 @@ public:
             );
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindFramebufferNull(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                         int32_t buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -522,10 +542,12 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BindRenderbuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindRenderbuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                      v8::Local<v8::Object> buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -547,7 +569,9 @@ public:
             );
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindRenderbufferNull(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                          int32_t buffer_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -561,9 +585,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BindTexture(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindTexture(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                 v8::Local<v8::Object> texture_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -581,7 +607,9 @@ public:
             );
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindTextureNull(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                     int32_t texture_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -595,9 +623,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BlendColor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBlendColor(v8::Local<v8::Object> receiver_obj, double red, double green, double blue,
                    double alpha) {
@@ -614,9 +644,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BlendEquationSeparate(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBlendEquationSeparate(v8::Local<v8::Object> receiver_obj, uint32_t modeRGB,
                                           uint32_t modeAlpha) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -630,9 +662,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BlendEquation(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBlendEquation(v8::Local<v8::Object> receiver_obj, uint32_t mode) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -643,9 +677,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BlendFuncSeparate(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBlendFuncSeparate(v8::Local<v8::Object> receiver_obj, uint32_t srcRGB, uint32_t dstRGB,
                           uint32_t srcAlpha, uint32_t dstAlpha) {
@@ -662,9 +698,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BlendFunc(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBlendFunc(v8::Local<v8::Object> receiver_obj, uint32_t sfactor, uint32_t dfactor) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -678,10 +716,12 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BufferData(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferDataTargetUsage(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -696,10 +736,12 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     /*
      *
-   static void FastBufferDataU8(v8::Local<v8::Object> receiver_obj, uint32_t target,
+#if V8_MAJOR_VERSION < 14
+    static void FastBufferDataU8(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                 const v8::FastApiArrayBufferView &srcData, uint32_t usage) {
        WebGLRenderingContext *ptr = GetPointer(receiver_obj);
        if (ptr == nullptr) {
@@ -714,9 +756,11 @@ public:
                ptr->GetState()
        );
    }
+#endif
 
 
-   static void FastBufferDataI8(v8::Local<v8::Object> receiver_obj, uint32_t target,
+#if V8_MAJOR_VERSION < 14
+    static void FastBufferDataI8(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                  const v8::FastApiArrayBufferView &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -730,7 +774,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataU16(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiArrayBufferView &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -745,7 +791,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataI16(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiArrayBufferView &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -761,9 +809,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     */
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataF32(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiTypedArray<float> &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -783,7 +833,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataF64(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiTypedArray<double> &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -803,7 +855,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataU32(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiTypedArray<uint32_t> &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -823,7 +877,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataI32(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   const v8::FastApiTypedArray<int32_t> &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -843,7 +899,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferDataArrayBuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                           const v8::FastApiArrayBuffer &srcData, uint32_t usage) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -859,7 +917,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferDataOS(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t offset,
                      uint32_t usage) {
@@ -876,9 +936,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BufferSubData(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferSubDataTargetOffset(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                               int32_t offset) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -892,9 +954,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     /*
-   static void
+#if V8_MAJOR_VERSION < 14
+    static void
    FastBufferSubDataU8(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                        const v8::FastApiArrayBufferView &srcData) {
        WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -910,9 +974,11 @@ public:
                ptr->GetState()
        );
    }
+#endif
 
 
-   static void
+#if V8_MAJOR_VERSION < 14
+    static void
    FastBufferSubDataI8(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                      const v8::FastApiArrayBufferView &srcData) {
        WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -932,9 +998,11 @@ public:
                ptr->GetState()
        );
    }
+#endif
 
 
-   static void
+#if V8_MAJOR_VERSION < 14
+    static void
    FastBufferSubDataU16(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                        const v8::FastApiArrayBufferView &srcData) {
        WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -954,9 +1022,11 @@ public:
                ptr->GetState()
        );
    }
+#endif
 
 
-   static void
+#if V8_MAJOR_VERSION < 14
+    static void
    FastBufferSubDataI16(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                         const v8::FastApiArrayBufferView&srcData) {
        WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -976,9 +1046,11 @@ public:
                ptr->GetState()
        );
    }
+#endif
 
 
    */
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferSubDataU32(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                          const v8::FastApiTypedArray<uint32_t> &srcData) {
@@ -999,8 +1071,10 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferSubDataI32(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                          const v8::FastApiTypedArray<int32_t> &srcData) {
@@ -1021,8 +1095,10 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferSubDataF32(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                          const v8::FastApiTypedArray<float> &srcData) {
@@ -1043,8 +1119,10 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBufferSubDataF64(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t offset,
                          const v8::FastApiTypedArray<double> &srcData) {
@@ -1065,8 +1143,10 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
 
+#if V8_MAJOR_VERSION < 14
     static void FastBufferSubDataArrayBuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                              int32_t offset,
                                              const v8::FastApiArrayBuffer &srcData) {
@@ -1082,9 +1162,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void CheckFramebufferStatus(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static uint32_t
     FastCheckFramebufferStatus(v8::Local<v8::Object> receiver_obj, uint32_t target) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1097,6 +1179,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void ClearColor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1108,6 +1191,7 @@ public:
         );
     }
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearColor(v8::Local<v8::Object> receiver_obj, double red, double green, double blue,
                    double alpha) {
@@ -1123,9 +1207,11 @@ public:
                 static_cast<float>(alpha)
         );
     }
+#endif
 
     static void ClearDepth(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastClearDepth(v8::Local<v8::Object> receiver_obj, double depth) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1137,9 +1223,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void ClearStencil(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastClearStencil(v8::Local<v8::Object> receiver_obj, int32_t stencil) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1151,6 +1239,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void Clear(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1164,6 +1253,7 @@ public:
         ptr->UpdateInvalidateState();
     }
 
+#if V8_MAJOR_VERSION < 14
     static void FastClear(v8::Local<v8::Object> receiver_obj, uint32_t mask) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1175,9 +1265,11 @@ public:
                 mask
         );
     }
+#endif
 
     static void ColorMask(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastColorMask(v8::Local<v8::Object> receiver_obj, bool red, bool green, bool blue, bool alpha) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1193,11 +1285,13 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void Commit(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void CompileShader(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastCompileShader(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> shader_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1216,6 +1310,7 @@ public:
         }
 
     }
+#endif
 
     static void CompressedTexImage2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1223,6 +1318,7 @@ public:
 
     static void CopyTexImage2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastCopyTexImage2D(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t level,
                        uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height,
@@ -1245,9 +1341,11 @@ public:
         );
 
     }
+#endif
 
     static void CopyTexSubImage2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastCopyTexSubImage2D(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t level,
                           int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, int32_t width,
@@ -1271,6 +1369,7 @@ public:
         );
 
     }
+#endif
 
     static void CreateBuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1286,6 +1385,7 @@ public:
 
     static void CullFace(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastCullFace(v8::Local<v8::Object> receiver_obj, uint32_t mode) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1299,9 +1399,11 @@ public:
         );
 
     }
+#endif
 
     static void DeleteBuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteBuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1321,9 +1423,11 @@ public:
         }
 
     }
+#endif
 
     static void DeleteFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDeleteFramebuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1343,9 +1447,11 @@ public:
         }
 
     }
+#endif
 
     static void DeleteProgram(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteProgram(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1366,9 +1472,11 @@ public:
 
 
     }
+#endif
 
     static void DeleteRenderbuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDeleteRenderbuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1391,9 +1499,11 @@ public:
 
 
     }
+#endif
 
     static void DeleteShader(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteShader(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1413,9 +1523,11 @@ public:
             }
         }
     }
+#endif
 
     static void DeleteTexture(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteTexture(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1434,9 +1546,11 @@ public:
             }
         }
     }
+#endif
 
     static void DepthFunc(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDepthFunc(v8::Local<v8::Object> receiver_obj, uint32_t func) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1448,9 +1562,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void DepthMask(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDepthMask(v8::Local<v8::Object> receiver_obj, bool mask) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1461,9 +1577,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void DepthRange(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDepthRange(v8::Local<v8::Object> receiver_obj, double zNear, double zFar) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1476,9 +1594,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void DetachShader(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDetachShader(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj,
                      v8::Local<v8::Object> shader_obj) {
@@ -1507,9 +1627,11 @@ public:
             );
         }
     }
+#endif
 
     static void DisableVertexAttribArray(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDisableVertexAttribArray(v8::Local<v8::Object> receiver_obj, uint32_t index) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1522,9 +1644,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void Disable(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDisable(v8::Local<v8::Object> receiver_obj, uint32_t cap) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1536,6 +1660,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void DrawArrays(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1550,6 +1675,7 @@ public:
         ptr->UpdateInvalidateState();
     }
 
+#if V8_MAJOR_VERSION < 14
     static void FastDrawArrays(v8::Local<v8::Object> receiver_obj, uint32_t mode, int32_t first,
                                int32_t count) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1565,10 +1691,12 @@ public:
         );
         ptr->UpdateInvalidateState();
     }
+#endif
 
     static void DrawElements(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDrawElements(v8::Local<v8::Object> receiver_obj, uint32_t mode, int32_t count, int32_t type,
                      int32_t offset) {
@@ -1587,9 +1715,11 @@ public:
         );
         ptr->UpdateInvalidateState();
     }
+#endif
 
     static void EnableVertexAttribArray(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastEnableVertexAttribArray(v8::Local<v8::Object> receiver_obj, uint32_t index) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1602,6 +1732,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void Enable(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1611,6 +1742,7 @@ public:
         );
     }
 
+#if V8_MAJOR_VERSION < 14
     static void FastEnable(v8::Local<v8::Object> receiver_obj, uint32_t cap) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1622,9 +1754,11 @@ public:
                 cap
         );
     }
+#endif
 
     static void Finish(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastFinish(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1635,7 +1769,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastFlush(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1646,11 +1782,13 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void Flush(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void FramebufferRenderbuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastFramebufferRenderbuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                             uint32_t attachment,
                                             uint32_t renderbuffertarget,
@@ -1675,9 +1813,11 @@ public:
             }
         }
     }
+#endif
 
     static void FramebufferTexture2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastFramebufferTexture2D(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                          uint32_t attachment, uint32_t textarget, int32_t level,
                                          v8::Local<v8::Object> texture_obj) {
@@ -1701,9 +1841,11 @@ public:
             }
         }
     }
+#endif
 
     static void FrontFace(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastFrontFace(v8::Local<v8::Object> receiver_obj, uint32_t mode) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1715,9 +1857,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void GenerateMipmap(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastGenerateMipmap(v8::Local<v8::Object> receiver_obj, uint32_t target) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1729,6 +1873,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void GetActiveAttrib(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1740,6 +1885,7 @@ public:
 
     static void GetBufferParameter(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static uint32_t
     FastGetBufferParameter(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t pname) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1755,6 +1901,7 @@ public:
         );
 
     }
+#endif
 
     static void GetContextAttributes(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1790,6 +1937,7 @@ public:
 
     static void GetVertexAttribOffset(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static int32_t
     FastGetVertexAttribOffset(v8::Local<v8::Object> receiver_obj, uint32_t index, uint32_t pname) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1803,11 +1951,13 @@ public:
                 pname,
                 ptr->GetState());
     }
+#endif
 
     static void GetVertexAttrib(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void Hint(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastHint(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t mode) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1818,9 +1968,11 @@ public:
                                  mode,
                                  ptr->GetState());
     }
+#endif
 
     static void IsBuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsBuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1840,9 +1992,11 @@ public:
 
         return false;
     }
+#endif
 
     static void IsContextLost(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsContextLost(v8::Local<v8::Object> receiver_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1855,9 +2009,11 @@ public:
 
         return ret;
     }
+#endif
 
     static void IsEnabled(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsEnabled(v8::Local<v8::Object> receiver_obj, uint32_t cap) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1867,9 +2023,11 @@ public:
         return canvas_native_webgl_is_enabled(
                 cap, ptr->GetState());
     }
+#endif
 
     static void IsFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsFramebuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1889,9 +2047,11 @@ public:
 
         return false;
     }
+#endif
 
     static void IsProgram(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsProgram(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1912,9 +2072,11 @@ public:
 
         return false;
     }
+#endif
 
     static void IsRenderbuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool
     FastIsRenderbuffer(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -1937,9 +2099,11 @@ public:
 
         return false;
     }
+#endif
 
     static void IsShader(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsShader(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1960,9 +2124,11 @@ public:
 
         return false;
     }
+#endif
 
     static void IsTexture(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsTexture(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1983,9 +2149,11 @@ public:
 
         return false;
     }
+#endif
 
     static void LineWidth(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastLineWidth(v8::Local<v8::Object> receiver_obj, double width) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1997,9 +2165,11 @@ public:
                 ptr->GetState());
 
     }
+#endif
 
     static void LinkProgram(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastLinkProgram(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -2016,9 +2186,11 @@ public:
             }
         }
     }
+#endif
 
     static void PixelStorei(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastPixelStoreiBool(v8::Local<v8::Object> receiver_obj, uint32_t pname, bool param) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2032,7 +2204,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastPixelStorei(v8::Local<v8::Object> receiver_obj, uint32_t pname, int32_t param) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -2045,9 +2219,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void PolygonOffset(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastPolygonOffset(v8::Local<v8::Object> receiver_obj, double factor, double units) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -2061,11 +2237,13 @@ public:
         );
 
     }
+#endif
 
     static void ReadPixels(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void RenderbufferStorage(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastRenderbufferStorage(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                         uint32_t internalFormat, int32_t width, int32_t height) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2082,9 +2260,11 @@ public:
         );
 
     }
+#endif
 
     static void SampleCoverage(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastSampleCoverage(v8::Local<v8::Object> receiver_obj, double value, bool invert) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -2098,9 +2278,11 @@ public:
         );
 
     }
+#endif
 
     static void Scissor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastScissor(v8::Local<v8::Object> receiver_obj, int32_t x, int32_t y, int32_t width,
                             int32_t height) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2117,11 +2299,13 @@ public:
         );
 
     }
+#endif
 
     static void ShaderSource(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void StencilFuncSeparate(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastStencilFuncSeparate(v8::Local<v8::Object> receiver_obj, uint32_t face, uint32_t func,
                             int32_t ref, uint32_t mask) {
@@ -2139,9 +2323,11 @@ public:
         );
 
     }
+#endif
 
     static void StencilFunc(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastStencilFunc(v8::Local<v8::Object> receiver_obj, uint32_t func, int32_t ref, uint32_t mask) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2157,9 +2343,11 @@ public:
         );
 
     }
+#endif
 
     static void StencilMaskSeparate(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastStencilMaskSeparate(v8::Local<v8::Object> receiver_obj, uint32_t face, uint32_t mask) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2174,9 +2362,11 @@ public:
         );
 
     }
+#endif
 
     static void StencilMask(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastStencilMask(v8::Local<v8::Object> receiver_obj, uint32_t mask) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -2190,9 +2380,11 @@ public:
         );
 
     }
+#endif
 
     static void StencilOpSeparate(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastStencilOpSeparate(v8::Local<v8::Object> receiver_obj, uint32_t face, uint32_t fail,
                           uint32_t zfail, uint32_t zpass) {
@@ -2210,9 +2402,11 @@ public:
         );
 
     }
+#endif
 
     static void StencilOp(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastStencilOp(v8::Local<v8::Object> receiver_obj, uint32_t fail, uint32_t zfail,
                               uint32_t zpass) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -2228,11 +2422,13 @@ public:
         );
 
     }
+#endif
 
     static void TexImage2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void TexParameterf(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastTexParameterf(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t pname,
                       double param) {
@@ -2249,9 +2445,11 @@ public:
         );
 
     }
+#endif
 
     static void TexParameteri(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastTexParameteri(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                   uint32_t pname, int32_t
                                   param) {
@@ -2268,6 +2466,7 @@ public:
         );
 
     }
+#endif
 
     static void TexSubImage2D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -2281,6 +2480,7 @@ public:
         );
     }
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1f(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   double v0) {
@@ -2299,9 +2499,11 @@ public:
             );
         }
     }
+#endif
 
     static void Uniform1iv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1iv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<int32_t> &value) {
@@ -2323,7 +2525,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1ivArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2353,11 +2557,13 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform1fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<float> &value) {
@@ -2379,7 +2585,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1fvArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2409,6 +2617,7 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform1i(const v8::FunctionCallbackInfo<v8::Value> &args);
@@ -2422,6 +2631,7 @@ public:
         );
     }
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1i(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   int32_t v0) {
@@ -2440,9 +2650,11 @@ public:
             );
         }
     }
+#endif
 
     static void Uniform2f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2f(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   double v0, double v1) {
@@ -2462,11 +2674,13 @@ public:
             );
         }
     }
+#endif
 
 
     static void Uniform2iv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2iv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<int32_t> &value) {
@@ -2488,7 +2702,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2ivArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2517,10 +2733,12 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform2fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<float> &value) {
@@ -2542,7 +2760,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2fvArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2571,10 +2791,12 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform2i(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2i(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   int32_t v0, int32_t v1) {
@@ -2594,10 +2816,12 @@ public:
             );
         }
     }
+#endif
 
 
     static void Uniform3f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3f(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   double v0, double v1, double v2) {
@@ -2618,11 +2842,13 @@ public:
             );
         }
     }
+#endif
 
 
     static void Uniform3iv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<float> &value) {
@@ -2644,7 +2870,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3fvArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2673,11 +2901,13 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform3fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3iv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<int32_t> &value) {
@@ -2699,7 +2929,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3ivArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2728,11 +2960,13 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform3i(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3i(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   int32_t v0, int32_t v1, int32_t v2) {
@@ -2753,10 +2987,12 @@ public:
             );
         }
     }
+#endif
 
     static void Uniform4f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4f(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   double v0, double v1, double v2, double v3) {
@@ -2778,10 +3014,12 @@ public:
             );
         }
     }
+#endif
 
 
     static void Uniform4iv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4iv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<int32_t> &value) {
@@ -2803,7 +3041,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4ivArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2833,10 +3073,12 @@ public:
 
         }
     }
+#endif
 
     static void Uniform4fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    const v8::FastApiTypedArray<float> &value) {
@@ -2858,7 +3100,9 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4fvArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                         v8::Local<v8::Array> value) {
@@ -2888,10 +3132,12 @@ public:
 
         }
     }
+#endif
 
 
     static void Uniform4i(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4i(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                   int32_t v0, int32_t v1, int32_t v2, int32_t v3) {
@@ -2913,11 +3159,13 @@ public:
             );
         }
     }
+#endif
 
 
     static void UniformMatrix2fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix2fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                          bool transpose, const v8::FastApiTypedArray<float> &value) {
@@ -2944,7 +3192,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastUniformMatrix2fvArray(v8::Local<v8::Object> receiver_obj,
                                           v8::Local<v8::Object> location_obj, bool transpose,
                                           v8::Local<v8::Array> value) {
@@ -2973,11 +3223,13 @@ public:
 
         }
     }
+#endif
 
 
     static void UniformMatrix3fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix3fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                          bool transpose, const v8::FastApiTypedArray<float> &value) {
@@ -3004,7 +3256,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastUniformMatrix3fvArray(v8::Local<v8::Object> receiver_obj,
                                           v8::Local<v8::Object> location_obj, bool transpose,
                                           v8::Local<v8::Array> value) {
@@ -3033,10 +3287,12 @@ public:
 
         }
     }
+#endif
 
 
     static void UniformMatrix4fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix4fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                          bool transpose, const v8::FastApiTypedArray<float> &value) {
@@ -3062,7 +3318,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastUniformMatrix4fvArray(v8::Local<v8::Object> receiver_obj,
                                           v8::Local<v8::Object> location_obj, bool transpose,
                                           v8::Local<v8::Array> value) {
@@ -3091,6 +3349,7 @@ public:
 
         }
     }
+#endif
 
     static void UseProgram(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -3104,6 +3363,7 @@ public:
     }
 
 
+#if V8_MAJOR_VERSION < 14
     static void FastUseProgramNull(v8::Local<v8::Object> receiver_obj, uint32_t program) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -3115,7 +3375,9 @@ public:
                 program
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUseProgram(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3134,9 +3396,11 @@ public:
 
 
     }
+#endif
 
     static void ValidateProgram(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastValidateProgram(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3157,9 +3421,11 @@ public:
         }
 
     }
+#endif
 
     static void VertexAttrib1f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttrib1f(v8::Local<v8::Object> receiver_obj, uint32_t index, float v0) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -3170,9 +3436,11 @@ public:
                 index, v0, ptr->GetState());
 
     }
+#endif
 
     static void VertexAttrib1fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttrib1fv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                     const v8::FastApiTypedArray<float> &value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3190,9 +3458,11 @@ public:
                 index, data, size,
                 ptr->GetState());
     }
+#endif
 
     static void VertexAttrib2f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttrib2f(v8::Local<v8::Object> receiver_obj, uint32_t index, float v0, float v1) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3204,9 +3474,11 @@ public:
                 index, v0, v1, ptr->GetState());
 
     }
+#endif
 
     static void VertexAttrib2fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttrib2fv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                     const v8::FastApiTypedArray<float> &value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3224,9 +3496,11 @@ public:
                 index, data, size,
                 ptr->GetState());
     }
+#endif
 
     static void VertexAttrib3f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttrib3f(v8::Local<v8::Object> receiver_obj, uint32_t index, float v0, float v1,
                        float v2) {
@@ -3239,9 +3513,11 @@ public:
                 index, v0, v1, v2, ptr->GetState());
 
     }
+#endif
 
     static void VertexAttrib3fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttrib3fv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                     const v8::FastApiTypedArray<float> &value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3259,9 +3535,11 @@ public:
                 index, data, size,
                 ptr->GetState());
     }
+#endif
 
     static void VertexAttrib4f(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttrib4f(v8::Local<v8::Object> receiver_obj, uint32_t index, float v0, float v1,
                        float v2, float v3) {
@@ -3274,9 +3552,11 @@ public:
                 index, v0, v1, v2, v3, ptr->GetState());
 
     }
+#endif
 
     static void VertexAttrib4fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttrib4fv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                     const v8::FastApiTypedArray<float> &value) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3294,9 +3574,11 @@ public:
                 index, data, size,
                 ptr->GetState());
     }
+#endif
 
     static void VertexAttribPointer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttribPointer(v8::Local<v8::Object> receiver_obj, uint32_t index, int32_t size,
                             uint32_t type, bool normalized, int32_t stride, int32_t offset) {
@@ -3311,6 +3593,7 @@ public:
                 stride, os,
                 ptr->GetState());
     }
+#endif
 
 
     static void Viewport(const v8::FunctionCallbackInfo<v8::Value> &args);
@@ -3326,6 +3609,7 @@ public:
 
     }
 
+#if V8_MAJOR_VERSION < 14
     static void FastViewport(v8::Local<v8::Object> receiver_obj, double x, double y, double width,
                              double height) {
         WebGLRenderingContext *ptr = GetPointer(receiver_obj);
@@ -3338,6 +3622,7 @@ public:
                 x, y, width, height
         );
     }
+#endif
 
     static void __ToDataURL(const v8::FunctionCallbackInfo<v8::Value> &args);
 

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContextBase.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContextBase.cpp
@@ -29,9 +29,9 @@ WebGLRenderingContextBase::WebGLRenderingContextBase(WebGLState* state,
 }
 
 
-void WebGLRenderingContextBase::GetContinuousRenderMode(v8::Local<v8::String> property,
+void WebGLRenderingContextBase::GetContinuousRenderMode(v8::Local<v8::Name> property,
                                                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    WebGLRenderingContextBase *ptr = GetPointer(info.This());
+    WebGLRenderingContextBase *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(false);
         return;
@@ -39,10 +39,10 @@ void WebGLRenderingContextBase::GetContinuousRenderMode(v8::Local<v8::String> pr
     info.GetReturnValue().Set(ptr->continuousRender_);
 }
 
-void WebGLRenderingContextBase::SetContinuousRenderMode(v8::Local<v8::String> property,
+void WebGLRenderingContextBase::SetContinuousRenderMode(v8::Local<v8::Name> property,
                                                            v8::Local<v8::Value> value,
                                                            const v8::PropertyCallbackInfo<void> &info) {
-    WebGLRenderingContextBase *ptr = GetPointer(info.This());
+    WebGLRenderingContextBase *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContextBase.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLRenderingContextBase.h
@@ -25,7 +25,7 @@ public:
     WebGLRenderingContextBase(WebGLState* state, WebGLRenderingVersion version);
 
     static WebGLRenderingContextBase *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }
@@ -33,10 +33,10 @@ public:
     }
 
 
-    static void GetContinuousRenderMode(v8::Local<v8::String> property,
+    static void GetContinuousRenderMode(v8::Local<v8::Name> property,
                                                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetContinuousRenderMode(v8::Local<v8::String> property,
+    static void SetContinuousRenderMode(v8::Local<v8::Name> property,
                                                             v8::Local<v8::Value> value,
                                                             const v8::PropertyCallbackInfo<void> &info);
 

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShader.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShader.h
@@ -35,13 +35,13 @@ public:
         auto object = WebGLShader::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( shader, NativeType::WebGLShader);
-        object->SetAlignedPointerInInternalField(0, shader);
+        canvas::SetAlignedPointer(object, 0, shader);
         shader->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLShader *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShaderPrecisionFormatImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShaderPrecisionFormatImpl.cpp
@@ -10,7 +10,7 @@ WebGLShaderPrecisionFormatImpl::WebGLShaderPrecisionFormatImpl(
 
 void WebGLShaderPrecisionFormatImpl::GetRangeMin(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(info.This());
+    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -22,7 +22,7 @@ void WebGLShaderPrecisionFormatImpl::GetRangeMin(v8::Local<v8::Name> property,
 
 void WebGLShaderPrecisionFormatImpl::GetRangeMax(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(info.This());
+    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;
@@ -35,7 +35,7 @@ void WebGLShaderPrecisionFormatImpl::GetRangeMax(v8::Local<v8::Name> property,
 
 void WebGLShaderPrecisionFormatImpl::GetPrecision(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(info.This());
+    WebGLShaderPrecisionFormatImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         info.GetReturnValue().Set(0);
         return;

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShaderPrecisionFormatImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLShaderPrecisionFormatImpl.h
@@ -52,13 +52,13 @@ public:
         auto object = WebGLShaderPrecisionFormatImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(shaderPrecisionFormat, NativeType::WebGLShaderPrecisionFormat);
-        object->SetAlignedPointerInInternalField(0, shaderPrecisionFormat);
+        canvas::SetAlignedPointer(object, 0, shaderPrecisionFormat);
         shaderPrecisionFormat->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLShaderPrecisionFormatImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLTexture.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLTexture.h
@@ -36,13 +36,13 @@ public:
         auto object = WebGLTexture::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(texture, NativeType::WebGLTexture);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLTexture *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/WebGLUniformLocation.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/WebGLUniformLocation.h
@@ -42,13 +42,13 @@ public:
         auto object = WebGLUniformLocation::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(uniformLocation, NativeType::WebGLUniformLocation);
-        object->SetAlignedPointerInInternalField(0, uniformLocation);
+        canvas::SetAlignedPointer(object, 0, uniformLocation);
         uniformLocation->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLUniformLocation *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/ANGLE_instanced_arraysImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/ANGLE_instanced_arraysImpl.cpp
@@ -10,19 +10,19 @@ ANGLE_instanced_arraysImpl::ANGLE_instanced_arraysImpl(ANGLE_instanced_arrays *a
 
 
 v8::CFunction ANGLE_instanced_arraysImpl::fast_draw_arrays_instanced_angle_(
-        v8::CFunction::Make(ANGLE_instanced_arraysImpl::FastDrawArraysInstancedANGLE));
+        CANVAS_FAST_FUNCTION(ANGLE_instanced_arraysImpl::FastDrawArraysInstancedANGLE));
 
 
 v8::CFunction ANGLE_instanced_arraysImpl::fast_draw_elements_instanced_angle_(
-        v8::CFunction::Make(ANGLE_instanced_arraysImpl::FastDrawElementsInstancedANGLE));
+        CANVAS_FAST_FUNCTION(ANGLE_instanced_arraysImpl::FastDrawElementsInstancedANGLE));
 
 v8::CFunction ANGLE_instanced_arraysImpl::fast_vertex_attrib_divisor_angle_(
-        v8::CFunction::Make(ANGLE_instanced_arraysImpl::FastVertexAttribDivisorANGLE));
+        CANVAS_FAST_FUNCTION(ANGLE_instanced_arraysImpl::FastVertexAttribDivisorANGLE));
 
 
 ANGLE_instanced_arraysImpl *
 ANGLE_instanced_arraysImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/ANGLE_instanced_arraysImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/ANGLE_instanced_arraysImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = ANGLE_instanced_arraysImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(arrays, NativeType::ANGLE_instanced_arrays);
-        object->SetAlignedPointerInInternalField(0, arrays);
+        canvas::SetAlignedPointer(object, 0, arrays);
         arrays->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_blend_minmaxImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_blend_minmaxImpl.h
@@ -19,7 +19,7 @@ public:
         auto object = EXT_blend_minmaxImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( minmax, NativeType::EXT_blend_minmax);
-        object->SetAlignedPointerInInternalField(0, minmax);
+        canvas::SetAlignedPointer(object, 0, minmax);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "EXT_blend_minmax"));
         minmax->BindFinalizer(isolate, object);
@@ -27,7 +27,7 @@ public:
     }
 
     static EXT_blend_minmaxImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_color_buffer_half_floatImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_color_buffer_half_floatImpl.h
@@ -19,7 +19,7 @@ public:
         auto object = EXT_color_buffer_half_floatImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( buffer, NativeType::EXT_color_buffer_half_float);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "EXT_color_buffer_half_float"));
         buffer->BindFinalizer(isolate, object);
@@ -27,7 +27,7 @@ public:
     }
 
     static EXT_color_buffer_half_floatImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_disjoint_timer_queryImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_disjoint_timer_queryImpl.cpp
@@ -74,7 +74,7 @@ v8::Local<v8::FunctionTemplate> EXT_disjoint_timer_queryImpl::GetCtor(v8::Isolat
 
 EXT_disjoint_timer_queryImpl *
 EXT_disjoint_timer_queryImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_disjoint_timer_queryImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_disjoint_timer_queryImpl.h
@@ -29,7 +29,7 @@ public:
         auto object = EXT_disjoint_timer_queryImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( query, NativeType::EXT_disjoint_timer_query);
-        object->SetAlignedPointerInInternalField(0, query);
+        canvas::SetAlignedPointer(object, 0, query);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "EXT_disjoint_timer_query"));
         query->BindFinalizer(isolate, object);

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_sRGBImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_sRGBImpl.h
@@ -46,13 +46,13 @@ public:
         auto object = EXT_sRGBImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( extSrgb, NativeType::EXT_sRGB);
-        object->SetAlignedPointerInInternalField(0, extSrgb);
+        canvas::SetAlignedPointer(object, 0, extSrgb);
         extSrgb->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static EXT_sRGBImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_shader_texture_lodImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_shader_texture_lodImpl.h
@@ -36,13 +36,13 @@ public:
         auto object = EXT_shader_texture_lodImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( texture, NativeType::EXT_shader_texture_lod);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static EXT_shader_texture_lodImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_texture_filter_anisotropicImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/EXT_texture_filter_anisotropicImpl.h
@@ -44,13 +44,13 @@ public:
         auto object = EXT_texture_filter_anisotropicImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( filterAnisotropic, NativeType::EXT_texture_filter_anisotropic);
-        object->SetAlignedPointerInInternalField(0, filterAnisotropic);
+        canvas::SetAlignedPointer(object, 0, filterAnisotropic);
         filterAnisotropic->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static EXT_texture_filter_anisotropicImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_element_index_uintImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_element_index_uintImpl.h
@@ -44,7 +44,7 @@ public:
         auto object = OES_element_index_uintImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( element, NativeType::OES_element_index_uint);
-        object->SetAlignedPointerInInternalField(0, element);
+        canvas::SetAlignedPointer(object, 0, element);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "OES_element_index_uint")).FromJust();
         element->BindFinalizer(isolate, object);
@@ -52,7 +52,7 @@ public:
     }
 
     static OES_element_index_uintImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_fbo_render_mipmap.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_fbo_render_mipmap.h
@@ -38,7 +38,7 @@ public:
         auto object = OES_fbo_render_mipmapImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( mipmap, NativeType::OES_fbo_render_mipmap);
-        object->SetAlignedPointerInInternalField(0, mipmap);
+        canvas::SetAlignedPointer(object, 0, mipmap);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "OES_fbo_render_mipmap")).FromJust();
         mipmap->BindFinalizer(isolate, object);
@@ -46,7 +46,7 @@ public:
     }
 
     static OES_fbo_render_mipmapImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_standard_derivativesImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_standard_derivativesImpl.h
@@ -41,13 +41,13 @@ public:
         auto object = OES_standard_derivativesImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( derivatives, NativeType::OES_standard_derivatives);
-        object->SetAlignedPointerInInternalField(0, derivatives);
+        canvas::SetAlignedPointer(object, 0, derivatives);
         derivatives->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_standard_derivativesImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_floatImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_floatImpl.h
@@ -37,13 +37,13 @@ public:
         auto object = WebGLShader::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( texture, NativeType::OES_texture_float);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_texture_floatImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_float_linearImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_float_linearImpl.h
@@ -36,13 +36,13 @@ public:
         auto object = OES_texture_float_linearImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( texture, NativeType::OES_texture_float_linear);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_texture_float_linearImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_half_floatImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_half_floatImpl.h
@@ -39,13 +39,13 @@ public:
         auto object = OES_texture_half_floatImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( texture, NativeType::OES_texture_half_float);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_texture_half_floatImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_half_float_linearImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_texture_half_float_linearImpl.h
@@ -39,13 +39,13 @@ public:
         auto object = OES_texture_half_float_linearImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( texture, NativeType::OES_texture_half_float_linear);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_texture_half_float_linearImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_vertex_array_objectImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_vertex_array_objectImpl.cpp
@@ -12,15 +12,15 @@ OES_vertex_array_objectImpl::OES_vertex_array_objectImpl(OES_vertex_array_object
 
 
 v8::CFunction OES_vertex_array_objectImpl::fast_delete_vertex_array_oes_(
-        v8::CFunction::Make(OES_vertex_array_objectImpl::FastDeleteVertexArrayOES));
+        CANVAS_FAST_FUNCTION(OES_vertex_array_objectImpl::FastDeleteVertexArrayOES));
 
 
 v8::CFunction OES_vertex_array_objectImpl::fast_is_vertex_array_oes_(
-        v8::CFunction::Make(OES_vertex_array_objectImpl::FastIsVertexArrayOES));
+        CANVAS_FAST_FUNCTION(OES_vertex_array_objectImpl::FastIsVertexArrayOES));
 
 
 v8::CFunction OES_vertex_array_objectImpl::fast_bind_vertex_array_oes_(
-        v8::CFunction::Make(OES_vertex_array_objectImpl::FastBindVertexArrayOES));
+        CANVAS_FAST_FUNCTION(OES_vertex_array_objectImpl::FastBindVertexArrayOES));
 
 void OES_vertex_array_objectImpl::CreateVertexArrayOES(
         const v8::FunctionCallbackInfo<v8::Value> &args) {

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_vertex_array_objectImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/OES_vertex_array_objectImpl.h
@@ -72,13 +72,13 @@ public:
         auto object = OES_vertex_array_objectImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(vertexArrayObject, NativeType::OES_vertex_array_object);
-        object->SetAlignedPointerInInternalField(0, vertexArrayObject);
+        canvas::SetAlignedPointer(object, 0, vertexArrayObject);
         vertexArrayObject->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static OES_vertex_array_objectImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_color_buffer_floatImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_color_buffer_floatImpl.h
@@ -48,13 +48,13 @@ public:
         auto object = WEBGL_color_buffer_floatImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( buffer, NativeType::WEBGL_color_buffer_float);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         buffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_color_buffer_floatImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_atcImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_atcImpl.h
@@ -46,13 +46,13 @@ public:
         auto object = WEBGL_compressed_texture_atcImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( compressedTextureAtc, NativeType::WEBGL_compressed_texture_atc);
-        object->SetAlignedPointerInInternalField(0, compressedTextureAtc);
+        canvas::SetAlignedPointer(object, 0, compressedTextureAtc);
         compressedTextureAtc->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_compressed_texture_atcImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_etc1Impl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_etc1Impl.h
@@ -44,13 +44,13 @@ public:
         auto object = WEBGL_compressed_texture_etc1Impl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( compressedTextureEtc1, NativeType::WEBGL_compressed_texture_etc1);
-        object->SetAlignedPointerInInternalField(0, compressedTextureEtc1);
+        canvas::SetAlignedPointer(object, 0, compressedTextureEtc1);
         compressedTextureEtc1->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_compressed_texture_etc1Impl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_etcImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_etcImpl.h
@@ -71,7 +71,7 @@ public:
         auto object = WEBGL_compressed_texture_etcImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( compressedTextureEtc, NativeType::WEBGL_compressed_texture_etc);
-        object->SetAlignedPointerInInternalField(0, compressedTextureEtc);
+        canvas::SetAlignedPointer(object, 0, compressedTextureEtc);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "WEBGL_compressed_texture_etc")).FromJust();
         compressedTextureEtc->BindFinalizer(isolate, object);
@@ -79,7 +79,7 @@ public:
     }
 
     static WEBGL_compressed_texture_etcImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_pvrtcImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_pvrtcImpl.h
@@ -54,13 +54,13 @@ public:
         auto object = WEBGL_compressed_texture_pvrtcImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( compressedTexturePvrtc, NativeType::WEBGL_compressed_texture_pvrtc);
-        object->SetAlignedPointerInInternalField(0, compressedTexturePvrtc);
+        canvas::SetAlignedPointer(object, 0, compressedTexturePvrtc);
         compressedTexturePvrtc->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_compressed_texture_pvrtcImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_s3tcImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_s3tcImpl.h
@@ -50,13 +50,13 @@ public:
         auto object = WEBGL_compressed_texture_s3tcImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( textureS3Tc, NativeType::WEBGL_compressed_texture_s3tc);
-        object->SetAlignedPointerInInternalField(0, textureS3Tc);
+        canvas::SetAlignedPointer(object, 0, textureS3Tc);
         textureS3Tc->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_compressed_texture_s3tcImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_s3tc_srgbImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_compressed_texture_s3tc_srgbImpl.h
@@ -54,7 +54,7 @@ public:
         auto object = WEBGL_compressed_texture_s3tc_srgbImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( compressedTextureS3TcSrgb, NativeType::WEBGL_compressed_texture_s3tc_srgb);
-        object->SetAlignedPointerInInternalField(0, compressedTextureS3TcSrgb);
+        canvas::SetAlignedPointer(object, 0, compressedTextureS3TcSrgb);
         object->Set(context, ConvertToV8String(isolate, "ext_name"),
                     ConvertToV8String(isolate, "WEBGL_compressed_texture_s3tc_srgb"));
         compressedTextureS3TcSrgb->BindFinalizer(isolate, object);
@@ -62,7 +62,7 @@ public:
     }
 
     static WEBGL_compressed_texture_s3tc_srgbImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_depth_textureImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_depth_textureImpl.h
@@ -44,13 +44,13 @@ public:
         auto object = WEBGL_depth_textureImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( depthTexture, NativeType::WEBGL_depth_texture);
-        object->SetAlignedPointerInInternalField(0, depthTexture);
+        canvas::SetAlignedPointer(object, 0, depthTexture);
         depthTexture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_depth_textureImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_draw_buffersImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_draw_buffersImpl.cpp
@@ -9,7 +9,7 @@ WEBGL_draw_buffersImpl::WEBGL_draw_buffersImpl(WEBGL_draw_buffers *buffers) : bu
 }
 
 v8::CFunction WEBGL_draw_buffersImpl::fast_draw_buffers_webgl(
-        v8::CFunction::Make(WEBGL_draw_buffersImpl::FastDrawBuffersWEBGL));
+        CANVAS_FAST_FUNCTION(WEBGL_draw_buffersImpl::FastDrawBuffersWEBGL));
 
 void WEBGL_draw_buffersImpl::DrawBuffersWEBGL(
         const v8::FunctionCallbackInfo<v8::Value> &args) {

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_draw_buffersImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_draw_buffersImpl.h
@@ -127,13 +127,13 @@ public:
         auto object = WEBGL_draw_buffersImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(buffers, NativeType::WEBGL_draw_buffers);
-        object->SetAlignedPointerInInternalField(0, buffers);
+        canvas::SetAlignedPointer(object, 0, buffers);
         buffers->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_draw_buffersImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_lose_contextImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl/extensions/WEBGL_lose_contextImpl.h
@@ -52,13 +52,13 @@ public:
         auto object = WEBGL_lose_contextImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( element, NativeType::WEBGL_lose_context);
-        object->SetAlignedPointerInInternalField(0, element);
+        canvas::SetAlignedPointer(object, 0, element);
         element->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WEBGL_lose_contextImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGL2RenderingContext.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGL2RenderingContext.cpp
@@ -5,38 +5,38 @@
 #include "WebGL2RenderingContext.h"
 
 v8::CFunction WebGL2RenderingContext::fast_begin_query_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastBeginQuery));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBeginQuery));
 
 v8::CFunction WebGL2RenderingContext::fast_begin_transform_feedback_(
-                                                                     v8::CFunction::Make(WebGL2RenderingContext::FastBeginTransformFeedback));
+                                                                     CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBeginTransformFeedback));
 
 v8::CFunction WebGL2RenderingContext::fast_bind_vertex_array_(
-                                                              v8::CFunction::Make(WebGL2RenderingContext::FastBindVertexArray));
+                                                              CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBindVertexArray));
 
 
 v8::CFunction WebGL2RenderingContext::fast_bind_buffer_base_(
-                                                             v8::CFunction::Make(WebGL2RenderingContext::FastBindBufferBase));
+                                                             CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBindBufferBase));
 
 v8::CFunction WebGL2RenderingContext::fast_bind_buffer_range_(
-                                                              v8::CFunction::Make(WebGL2RenderingContext::FastBindBufferRange));
+                                                              CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBindBufferRange));
 
 v8::CFunction WebGL2RenderingContext::fast_bind_sampler_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastBindSampler));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBindSampler));
 
 v8::CFunction WebGL2RenderingContext::fast_bind_transform_feedback_(
-                                                                    v8::CFunction::Make(WebGL2RenderingContext::FastBindTransformFeedback));
+                                                                    CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBindTransformFeedback));
 
 v8::CFunction WebGL2RenderingContext::fast_blit_framebuffer_(
-                                                             v8::CFunction::Make(WebGL2RenderingContext::FastBlitFramebuffer));
+                                                             CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastBlitFramebuffer));
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_fi_(
-                                                            v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferfi));
+                                                            CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferfi));
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_fv_(
-                                                            v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferfv));
+                                                            CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferfv));
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_fv_array_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferfvArray));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferfvArray));
 
 const v8::CFunction fast_clear_buffer_fv_overloads_[] = {
     WebGL2RenderingContext::fast_clear_buffer_fv_,
@@ -44,10 +44,10 @@ const v8::CFunction fast_clear_buffer_fv_overloads_[] = {
 };
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_iv_(
-                                                            v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferiv));
+                                                            CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferiv));
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_iv_array_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferivArray));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferivArray));
 
 const v8::CFunction fast_clear_buffer_iv_overloads_[] = {
     WebGL2RenderingContext::fast_clear_buffer_iv_,
@@ -56,10 +56,10 @@ const v8::CFunction fast_clear_buffer_iv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_uiv_(
-                                                             v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferuiv));
+                                                             CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferuiv));
 
 v8::CFunction WebGL2RenderingContext::fast_clear_buffer_uiv_array_(
-                                                                   v8::CFunction::Make(WebGL2RenderingContext::FastClearBufferuivArray));
+                                                                   CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastClearBufferuivArray));
 
 const v8::CFunction fast_clear_buffer_uiv_overloads_[] = {
     WebGL2RenderingContext::fast_clear_buffer_uiv_,
@@ -67,58 +67,58 @@ const v8::CFunction fast_clear_buffer_uiv_overloads_[] = {
 };
 
 v8::CFunction WebGL2RenderingContext::fast_draw_arrays_instanced_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastDrawArraysInstanced));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDrawArraysInstanced));
 
 v8::CFunction WebGL2RenderingContext::fast_draw_buffers_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastDrawBuffers));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDrawBuffers));
 
 
 v8::CFunction WebGL2RenderingContext::fast_draw_elements_instanced_(
-                                                                    v8::CFunction::Make(WebGL2RenderingContext::FastDrawElementsInstanced));
+                                                                    CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDrawElementsInstanced));
 
 v8::CFunction WebGL2RenderingContext::fast_draw_range_elements_(
-                                                                v8::CFunction::Make(WebGL2RenderingContext::FastDrawRangeElements));
+                                                                CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDrawRangeElements));
 
 v8::CFunction WebGL2RenderingContext::fast_resume_transform_feedback_(
-                                                                      v8::CFunction::Make(WebGL2RenderingContext::FastResumeTransformFeedback));
+                                                                      CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastResumeTransformFeedback));
 
 v8::CFunction WebGL2RenderingContext::fast_sampler_parameterf_(
-                                                               v8::CFunction::Make(WebGL2RenderingContext::FastSamplerParameterf));
+                                                               CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastSamplerParameterf));
 
 v8::CFunction WebGL2RenderingContext::fast_sampler_parameteri_(
-                                                               v8::CFunction::Make(WebGL2RenderingContext::FastSamplerParameteri));
+                                                               CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastSamplerParameteri));
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_1ui_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastUniform1ui));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform1ui));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_1uiv_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastUniform1uiv));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform1uiv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_2ui_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastUniform2ui));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform2ui));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_2uiv_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastUniform2uiv));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform2uiv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_3ui_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastUniform3ui));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform3ui));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_3uiv_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastUniform3uiv));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform3uiv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_4ui_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastUniform4ui));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform4ui));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_4uiv_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastUniform4uiv));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniform4uiv));
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_2x3fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix2x3fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix2x3fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_2x3fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix2x3fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix2x3fvArray));
 
 const v8::CFunction fast_uniform_matrix_2x3fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_2x3fv_,
@@ -127,10 +127,10 @@ const v8::CFunction fast_uniform_matrix_2x3fv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_2x4fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix2x4fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix2x4fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_2x4fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix2x4fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix2x4fvArray));
 
 const v8::CFunction fast_uniform_matrix_2x4fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_2x4fv_,
@@ -139,10 +139,10 @@ const v8::CFunction fast_uniform_matrix_2x4fv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_3x2fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix3x2fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix3x2fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_3x2fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix3x2fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix3x2fvArray));
 
 const v8::CFunction fast_uniform_matrix_3x2fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_3x2fv_,
@@ -150,10 +150,10 @@ const v8::CFunction fast_uniform_matrix_3x2fv_overloads_[] = {
 };
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_3x4fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix3x4fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix3x4fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_3x4fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix3x4fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix3x4fvArray));
 
 const v8::CFunction fast_uniform_matrix_3x4fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_3x4fv_,
@@ -162,10 +162,10 @@ const v8::CFunction fast_uniform_matrix_3x4fv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_4x2fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix4x2fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix4x2fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_4x2fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix4x2fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix4x2fvArray));
 
 const v8::CFunction fast_uniform_matrix_4x2fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_4x2fv_,
@@ -174,10 +174,10 @@ const v8::CFunction fast_uniform_matrix_4x2fv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_4x3fv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix4x3fv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix4x3fv));
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_matrix_4x3fv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastUniformMatrix4x3fvArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformMatrix4x3fvArray));
 
 const v8::CFunction fast_uniform_matrix_4x3fv_overloads_[] = {
     WebGL2RenderingContext::fast_uniform_matrix_4x3fv_,
@@ -185,18 +185,18 @@ const v8::CFunction fast_uniform_matrix_4x3fv_overloads_[] = {
 };
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_divisor_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribDivisor));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribDivisor));
 
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4i_(
-                                                               v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4i));
+                                                               CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4i));
 
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4iv_(
-                                                                v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4iv));
+                                                                CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4iv));
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4iv_array_(
-                                                                      v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4ivArray));
+                                                                      CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4ivArray));
 
 const v8::CFunction fast_vertex_attrib_i_4iv_overloads_[] = {
     WebGL2RenderingContext::fast_vertex_attrib_i_4iv_,
@@ -205,14 +205,14 @@ const v8::CFunction fast_vertex_attrib_i_4iv_overloads_[] = {
 
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4ui_(
-                                                                v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4ui));
+                                                                CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4ui));
 
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4uiv_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4uiv));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4uiv));
 
 v8::CFunction WebGL2RenderingContext::fast_vertex_attrib_i_4uiv_array_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastVertexAttribI4uivArray));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastVertexAttribI4uivArray));
 
 const v8::CFunction fast_vertex_attrib_i_4uiv_overloads_[] = {
     WebGL2RenderingContext::fast_vertex_attrib_i_4uiv_,
@@ -220,71 +220,71 @@ const v8::CFunction fast_vertex_attrib_i_4uiv_overloads_[] = {
 };
 
 v8::CFunction WebGL2RenderingContext::fast_uniform_block_binding_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastUniformBlockBinding));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastUniformBlockBinding));
 
 
 v8::CFunction WebGL2RenderingContext::fast_invalidate_framebuffer_(
-                                                                   v8::CFunction::Make(WebGL2RenderingContext::FastInvalidateFramebuffer));
+                                                                   CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastInvalidateFramebuffer));
 
 v8::CFunction WebGL2RenderingContext::fast_invalidate_sub_framebuffer_(
-                                                                       v8::CFunction::Make(WebGL2RenderingContext::FastInvalidateSubFramebuffer));
+                                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastInvalidateSubFramebuffer));
 
 
 v8::CFunction WebGL2RenderingContext::fast_copy_tex_sub_image_3d_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastCopyTexSubImage3D));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastCopyTexSubImage3D));
 
 v8::CFunction WebGL2RenderingContext::fast_copy_buffer_sub_data_(
-                                                                 v8::CFunction::Make(WebGL2RenderingContext::FastCopyBufferSubData));
+                                                                 CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastCopyBufferSubData));
 
 v8::CFunction WebGL2RenderingContext::fast_delete_query_(
-                                                         v8::CFunction::Make(WebGL2RenderingContext::FastDeleteQuery));
+                                                         CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDeleteQuery));
 v8::CFunction WebGL2RenderingContext::fast_delete_sampler_(
-                                                           v8::CFunction::Make(WebGL2RenderingContext::FastDeleteSampler));
+                                                           CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDeleteSampler));
 v8::CFunction WebGL2RenderingContext::fast_delete_sync_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastDeleteSync));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDeleteSync));
 v8::CFunction WebGL2RenderingContext::fast_delete_transform_feedback_(
-                                                                      v8::CFunction::Make(WebGL2RenderingContext::FastDeleteTransformFeedback));
+                                                                      CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDeleteTransformFeedback));
 v8::CFunction WebGL2RenderingContext::fast_delete_vertex_array_(
-                                                                v8::CFunction::Make(WebGL2RenderingContext::FastDeleteVertexArray));
+                                                                CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastDeleteVertexArray));
 
 v8::CFunction WebGL2RenderingContext::fast_end_query_(
-                                                      v8::CFunction::Make(WebGL2RenderingContext::FastEndQuery));
+                                                      CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastEndQuery));
 
 v8::CFunction WebGL2RenderingContext::fast_end_transform_feedback_(
-                                                                   v8::CFunction::Make(WebGL2RenderingContext::FastEndTransformFeedback));
+                                                                   CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastEndTransformFeedback));
 
 v8::CFunction WebGL2RenderingContext::fast_framebuffer_texture_layer_(
-                                                                      v8::CFunction::Make(WebGL2RenderingContext::FastFramebufferTextureLayer));
+                                                                      CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastFramebufferTextureLayer));
 
 v8::CFunction WebGL2RenderingContext::fast_pause_transform_feedback_(
-                                                                     v8::CFunction::Make(WebGL2RenderingContext::FastPauseTransformFeedback));
+                                                                     CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastPauseTransformFeedback));
 
 
 v8::CFunction WebGL2RenderingContext::fast_read_buffer_(
-                                                        v8::CFunction::Make(WebGL2RenderingContext::FastReadBuffer));
+                                                        CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastReadBuffer));
 
 v8::CFunction WebGL2RenderingContext::fast_renderbuffer_storage_multisample_(
-                                                                             v8::CFunction::Make(WebGL2RenderingContext::FastRenderbufferStorageMultisample));
+                                                                             CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastRenderbufferStorageMultisample));
 
 
 v8::CFunction WebGL2RenderingContext::fast_is_query_(
-                                                     v8::CFunction::Make(WebGL2RenderingContext::FastIsQuery));
+                                                     CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastIsQuery));
 
 
 v8::CFunction WebGL2RenderingContext::fast_is_sampler_(
-                                                       v8::CFunction::Make(WebGL2RenderingContext::FastIsSampler));
+                                                       CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastIsSampler));
 
 
 v8::CFunction WebGL2RenderingContext::fast_is_sync_(
-                                                    v8::CFunction::Make(WebGL2RenderingContext::FastIsSync));
+                                                    CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastIsSync));
 
 
 v8::CFunction WebGL2RenderingContext::fast_is_transform_feedback_(
-                                                                  v8::CFunction::Make(WebGL2RenderingContext::FastIsTransformFeedback));
+                                                                  CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastIsTransformFeedback));
 
 
 v8::CFunction WebGL2RenderingContext::fast_is_vertex_array_(
-                                                            v8::CFunction::Make(WebGL2RenderingContext::FastIsVertexArray));
+                                                            CANVAS_FAST_FUNCTION(WebGL2RenderingContext::FastIsVertexArray));
 
 
 
@@ -327,7 +327,7 @@ v8::Local<v8::FunctionTemplate> WebGL2RenderingContext::GetCtor(v8::Isolate *iso
 }
 
 WebGL2RenderingContext *WebGL2RenderingContext::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGL2RenderingContext.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGL2RenderingContext.h
@@ -116,7 +116,7 @@ public:
         auto object = WebGL2RenderingContext::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(renderingContext, NativeType::WebGLRenderingContextBase);
-        object->SetAlignedPointerInInternalField(0, renderingContext);
+        canvas::SetAlignedPointer(object, 0, renderingContext);
         renderingContext->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
@@ -133,6 +133,7 @@ public:
 
     static void BeginQuery(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBeginQuery(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                v8::Local<v8::Object> query_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -153,9 +154,11 @@ public:
             }
         }
     }
+#endif
 
     static void BeginTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBeginTransformFeedback(v8::Local<v8::Object> receiver_obj, uint32_t value) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -167,9 +170,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void BindBufferBase(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBindBufferBase(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t index,
                        v8::Local<v8::Object> buffer_obj) {
@@ -191,9 +196,11 @@ public:
             );
         }
     }
+#endif
 
     static void BindBufferRange(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBindBufferRange(v8::Local<v8::Object> receiver_obj, uint32_t target, uint32_t index,
                         v8::Local<v8::Object> buffer_obj, int32_t offset, int32_t size) {
@@ -216,9 +223,11 @@ public:
             );
         }
     }
+#endif
 
     static void BindSampler(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindSampler(v8::Local<v8::Object> receiver_obj, uint32_t unit,
                                 v8::Local<v8::Object> sampler_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -237,9 +246,11 @@ public:
             );
         }
     }
+#endif
 
     static void BindTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindTransformFeedback(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                           v8::Local<v8::Object> transformer_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -260,6 +271,7 @@ public:
             );
         }
     }
+#endif
 
     static void BindVertexArray(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -272,6 +284,7 @@ public:
 
     }
 
+#if V8_MAJOR_VERSION < 14
     static void FastBindVertexArray(v8::Local<v8::Object> receiver_obj, uint32_t vertex_array) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -283,9 +296,11 @@ public:
                 vertex_array
         );
     }
+#endif
 
     static void BlitFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastBlitFramebuffer(v8::Local<v8::Object> receiver_obj, int32_t srcX0, int32_t srcY0,
                         int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1,
@@ -310,9 +325,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void ClearBufferfi(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferfi(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                       double depth, int32_t stencil) {
@@ -330,9 +347,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void ClearBufferfv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferfv(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                       const v8::FastApiTypedArray<float> &values) {
@@ -354,7 +373,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferfvArray(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                            v8::Local<v8::Array> values) {
@@ -381,9 +402,11 @@ public:
             );
         }
     }
+#endif
 
     static void ClearBufferiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferiv(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                       const v8::FastApiTypedArray<int32_t> &values) {
@@ -405,7 +428,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferivArray(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                            v8::Local<v8::Array> values) {
@@ -432,11 +457,13 @@ public:
             );
         }
     }
+#endif
 
 
     static void ClearBufferuiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferuiv(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                        const v8::FastApiTypedArray<uint32_t> &values) {
@@ -458,7 +485,9 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastClearBufferuivArray(v8::Local<v8::Object> receiver_obj, uint32_t buffer, int32_t drawbuffer,
                             v8::Local<v8::Array> values) {
@@ -485,6 +514,7 @@ public:
             );
         }
     }
+#endif
 
     static void ClientWaitSync(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -492,6 +522,7 @@ public:
 
     static void CopyBufferSubData(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastCopyBufferSubData(v8::Local<v8::Object> receiver_obj, uint32_t readTarget,
                                       uint32_t writeTarget, int32_t readOffset, int32_t writeOffset,
                                       uint32_t size) {
@@ -509,9 +540,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void CopyTexSubImage3D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastCopyTexSubImage3D(v8::Local<v8::Object> receiver_obj, uint32_t target, int32_t level,
                           int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t x, int32_t y,
@@ -535,6 +568,7 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void CreateQuery(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -546,6 +580,7 @@ public:
 
     static void DeleteQuery(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDeleteQuery(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> query_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -565,9 +600,11 @@ public:
             }
         }
     }
+#endif
 
     static void DeleteSampler(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDeleteSampler(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sampler_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -588,9 +625,11 @@ public:
             }
         }
     }
+#endif
 
     static void DeleteSync(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteSync(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sync_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -609,9 +648,11 @@ public:
             }
         }
     }
+#endif
 
     static void DeleteTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteTransformFeedback(v8::Local<v8::Object> receiver_obj,
                                             v8::Local<v8::Object> transform_feedback_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -633,9 +674,11 @@ public:
             }
         }
     }
+#endif
 
     static void DeleteVertexArray(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDeleteVertexArray(v8::Local<v8::Object> receiver_obj,
                                       v8::Local<v8::Object> vertex_array_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -655,9 +698,11 @@ public:
             }
         }
     }
+#endif
 
     static void DrawArraysInstanced(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDrawArraysInstanced(v8::Local<v8::Object> receiver_obj, uint32_t mode, int32_t first,
                             int32_t count, int32_t instanceCount) {
@@ -677,9 +722,11 @@ public:
 
         ptr->UpdateInvalidateState();
     }
+#endif
 
     static void DrawBuffers(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastDrawBuffers(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Array> buffers) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -701,9 +748,11 @@ public:
         }
 
     }
+#endif
 
     static void DrawElementsInstanced(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDrawElementsInstanced(v8::Local<v8::Object> receiver_obj, uint32_t mode, int32_t count,
                               uint32_t type, int32_t offset, int32_t instanceCount) {
@@ -724,9 +773,11 @@ public:
 
         ptr->UpdateInvalidateState();
     }
+#endif
 
     static void DrawRangeElements(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastDrawRangeElements(v8::Local<v8::Object> receiver_obj, uint32_t mode, uint32_t start,
                           uint32_t end, int32_t count, uint32_t type, int32_t offset) {
@@ -748,9 +799,11 @@ public:
 
         ptr->UpdateInvalidateState();
     }
+#endif
 
     static void EndQuery(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastEndQuery(v8::Local<v8::Object> receiver_obj, uint32_t target) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -760,9 +813,11 @@ public:
         canvas_native_webgl2_end_query(target,
                                        ptr->GetState());
     }
+#endif
 
     static void EndTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastEndTransformFeedback(v8::Local<v8::Object> receiver_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -772,11 +827,13 @@ public:
         canvas_native_webgl2_end_transform_feedback(
                 ptr->GetState());
     }
+#endif
 
     static void FenceSync(const v8::FunctionCallbackInfo<v8::Value> &args);
 
     static void FramebufferTextureLayer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastFramebufferTextureLayer(v8::Local<v8::Object> receiver_obj,
                                             v8::Local<v8::Object> texture_obj, uint32_t target,
                                             uint32_t attachment, int32_t level, int32_t layer) {
@@ -802,6 +859,7 @@ public:
 
         }
     }
+#endif
 
     static void GetActiveUniformBlockName(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -835,6 +893,7 @@ public:
 
     static void InvalidateFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastInvalidateFramebuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                               v8::Local<v8::Array> attachments) {
@@ -856,9 +915,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void InvalidateSubFramebuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastInvalidateSubFramebuffer(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                              v8::Local<v8::Array> attachments, int32_t x, int32_t y,
                                              int32_t width, int32_t height) {
@@ -886,9 +947,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void IsQuery(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsQuery(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> query_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -909,9 +972,11 @@ public:
         // todo check return
         return false;
     }
+#endif
 
     static void IsSampler(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool
     FastIsSampler(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sample_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -933,9 +998,11 @@ public:
         // todo check return
         return false;
     }
+#endif
 
     static void IsSync(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsSync(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sync_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -957,9 +1024,11 @@ public:
         // todo check return
         return false;
     }
+#endif
 
     static void IsTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool FastIsTransformFeedback(v8::Local<v8::Object> receiver_obj,
                                         v8::Local<v8::Object> feedback_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -981,9 +1050,11 @@ public:
         // todo check return
         return false;
     }
+#endif
 
     static void IsVertexArray(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static bool
     FastIsVertexArray(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> vertex_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1005,9 +1076,11 @@ public:
         // todo check return
         return false;
     }
+#endif
 
     static void PauseTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastPauseTransformFeedback(v8::Local<v8::Object> receiver_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1016,9 +1089,11 @@ public:
         canvas_native_webgl2_pause_transform_feedback(
                 ptr->GetState());
     }
+#endif
 
     static void ReadBuffer(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastReadBuffer(v8::Local<v8::Object> receiver_obj, uint32_t src) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1030,9 +1105,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void RenderbufferStorageMultisample(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastRenderbufferStorageMultisample(v8::Local<v8::Object> receiver_obj, uint32_t target,
                                        int32_t samples, uint32_t internalFormat, int32_t width,
@@ -1051,9 +1128,11 @@ public:
                 ptr->GetState()
         );
     }
+#endif
 
     static void ResumeTransformFeedback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastResumeTransformFeedback(v8::Local<v8::Object> receiver_obj) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
         if (ptr == nullptr) {
@@ -1063,9 +1142,11 @@ public:
         canvas_native_webgl2_resume_transform_feedback(
                 ptr->GetState());
     }
+#endif
 
     static void SamplerParameterf(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastSamplerParameterf(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sampler_obj,
                           uint32_t pname, double param) {
@@ -1087,10 +1168,12 @@ public:
         }
 
     }
+#endif
 
     static void SamplerParameteri(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastSamplerParameteri(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> sampler_obj,
                           uint32_t pname, int32_t param) {
@@ -1112,6 +1195,7 @@ public:
         }
 
     }
+#endif
 
     static void TexImage3D(const v8::FunctionCallbackInfo<v8::Value> &args);
 
@@ -1126,6 +1210,7 @@ public:
     static void Uniform1ui(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1ui(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    uint32_t v0) {
@@ -1151,9 +1236,11 @@ public:
         }
 
     }
+#endif
 
     static void Uniform1uiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform1uiv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                     const v8::FastApiTypedArray<uint32_t> &value) {
@@ -1175,9 +1262,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void Uniform2ui(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2ui(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    uint32_t v0, uint32_t v1) {
@@ -1203,9 +1292,11 @@ public:
         }
 
     }
+#endif
 
     static void Uniform2uiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform2uiv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                     const v8::FastApiTypedArray<uint32_t> &value) {
@@ -1227,9 +1318,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void Uniform3ui(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3ui(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    uint32_t v0, uint32_t v1, uint32_t v2) {
@@ -1255,9 +1348,11 @@ public:
         }
 
     }
+#endif
 
     static void Uniform3uiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform3uiv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                     const v8::FastApiTypedArray<uint32_t> &value) {
@@ -1279,9 +1374,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void Uniform4ui(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4ui(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                    uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
@@ -1307,10 +1404,12 @@ public:
         }
 
     }
+#endif
 
     static void Uniform4uiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniform4uiv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                     const v8::FastApiTypedArray<uint32_t> &value) {
@@ -1332,9 +1431,11 @@ public:
                     ptr->GetState());
         }
     }
+#endif
 
     static void UniformBlockBinding(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformBlockBinding(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> program_obj,
                             uint32_t uniformBlockIndex, uint32_t uniformBlockBinding) {
@@ -1361,9 +1462,11 @@ public:
         }
 
     }
+#endif
 
     static void UniformMatrix2x3fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix2x3fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1388,7 +1491,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix2x3fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1420,10 +1525,12 @@ public:
         }
 
     }
+#endif
 
     static void UniformMatrix2x4fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix2x4fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1448,7 +1555,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix2x4fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1480,10 +1589,12 @@ public:
         }
 
     }
+#endif
 
     static void UniformMatrix3x2fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix3x2fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1508,7 +1619,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix3x2fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1540,10 +1653,12 @@ public:
         }
 
     }
+#endif
 
     static void UniformMatrix3x4fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix3x4fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1568,7 +1683,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix3x4fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1600,10 +1717,12 @@ public:
         }
 
     }
+#endif
 
 
     static void UniformMatrix4x2fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix4x2fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1628,7 +1747,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix4x2fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1660,10 +1781,12 @@ public:
         }
 
     }
+#endif
 
     static void UniformMatrix4x3fv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix4x3fv(v8::Local<v8::Object> receiver_obj, v8::Local<v8::Object> location_obj,
                            bool transpose, const v8::FastApiTypedArray<float> &data_value) {
@@ -1688,7 +1811,9 @@ public:
         }
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastUniformMatrix4x3fvArray(v8::Local<v8::Object> receiver_obj,
                                 v8::Local<v8::Object> location_obj,
@@ -1720,9 +1845,11 @@ public:
         }
 
     }
+#endif
 
     static void VertexAttribDivisor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttribDivisor(v8::Local<v8::Object> receiver_obj, uint32_t index, uint32_t divisor) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1737,9 +1864,11 @@ public:
         );
 
     }
+#endif
 
     static void VertexAttribI4i(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttribI4i(v8::Local<v8::Object> receiver_obj, int32_t index, int32_t v0, int32_t v1,
                         int32_t v2, int32_t v3) {
@@ -1759,9 +1888,11 @@ public:
         );
 
     }
+#endif
 
     static void VertexAttribI4iv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttribI4iv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                      const v8::FastApiTypedArray<int32_t> &data_value) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1780,7 +1911,9 @@ public:
         );
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttribI4ivArray(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                           v8::Local<v8::Array> data_value) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1805,9 +1938,11 @@ public:
         }
 
     }
+#endif
 
     static void VertexAttribI4ui(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+#if V8_MAJOR_VERSION < 14
     static void
     FastVertexAttribI4ui(v8::Local<v8::Object> receiver_obj, uint32_t index, uint32_t v0,
                          uint32_t v1,
@@ -1828,10 +1963,12 @@ public:
         );
 
     }
+#endif
 
     static void VertexAttribI4uiv(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttribI4uiv(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                       const v8::FastApiTypedArray<uint32_t> &data_value) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1850,7 +1987,9 @@ public:
         );
 
     }
+#endif
 
+#if V8_MAJOR_VERSION < 14
     static void FastVertexAttribI4uivArray(v8::Local<v8::Object> receiver_obj, uint32_t index,
                                            v8::Local<v8::Array> data_value) {
         WebGL2RenderingContext *ptr = GetPointer(receiver_obj);
@@ -1875,5 +2014,6 @@ public:
         }
 
     }
+#endif
 
 };

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLQuery.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLQuery.h
@@ -36,13 +36,13 @@ public:
         auto object = WebGLQuery::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( query, NativeType::WebGLQuery);
-        object->SetAlignedPointerInInternalField(0, query);
+        canvas::SetAlignedPointer(object, 0, query);
         query->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLQuery *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLSampler.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLSampler.h
@@ -37,13 +37,13 @@ public:
         auto object = WebGLSampler::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( sampler, NativeType::WebGLSampler);
-        object->SetAlignedPointerInInternalField(0, sampler);
+        canvas::SetAlignedPointer(object, 0, sampler);
         sampler->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLSampler *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLSyncImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLSyncImpl.h
@@ -36,13 +36,13 @@ public:
         auto object = WebGLSyncImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( sync, NativeType::WebGLSync);
-        object->SetAlignedPointerInInternalField(0, sync);
+        canvas::SetAlignedPointer(object, 0, sync);
         sync->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLSyncImpl *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLTransformFeedback.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLTransformFeedback.h
@@ -38,13 +38,13 @@ public:
         auto object = WebGLTransformFeedback::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType( feedback, NativeType::WebGLTransformFeedback);
-        object->SetAlignedPointerInInternalField(0, feedback);
+        canvas::SetAlignedPointer(object, 0, feedback);
         feedback->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLTransformFeedback *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLVertexArrayObject.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgl2/WebGLVertexArrayObject.h
@@ -39,13 +39,13 @@ public:
         auto object = WebGLVertexArrayObject::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(vertexArrayObject, NativeType::WebGLVertexArrayObject);
-        object->SetAlignedPointerInInternalField(0, vertexArrayObject);
+        canvas::SetAlignedPointer(object, 0, vertexArrayObject);
         vertexArrayObject->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
 
     static WebGLVertexArrayObject *GetPointer(const v8::Local<v8::Object> &object) {
-        auto ptr = object->GetAlignedPointerFromInternalField(0);
+        auto ptr = canvas::GetAlignedPointer(object, 0);
         if (ptr == nullptr) {
             return nullptr;
         }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.cpp
@@ -25,7 +25,7 @@ void GPUAdapterImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isola
 }
 
 GPUAdapterImpl *GPUAdapterImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -80,7 +80,7 @@ v8::Local<v8::FunctionTemplate> GPUAdapterImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUAdapterImpl::GetFeatures(v8::Local<v8::Name> name,
                             const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto context = isolate->GetCurrentContext();
@@ -112,7 +112,7 @@ GPUAdapterImpl::GetFeatures(v8::Local<v8::Name> name,
 void
 GPUAdapterImpl::GetIsFallbackAdapter(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         info.GetReturnValue().Set(
                 canvas_native_webgpu_adapter_is_fallback_adapter(ptr->GetGPUAdapter())
@@ -125,7 +125,7 @@ GPUAdapterImpl::GetIsFallbackAdapter(v8::Local<v8::Name> name,
 void
 GPUAdapterImpl::GetLimits(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto limits = canvas_native_webgpu_adapter_get_limits(ptr->GetGPUAdapter());
         auto ret = GPUSupportedLimitsImpl::NewInstance(info.GetIsolate(),

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterImpl.h
@@ -33,7 +33,7 @@ public:
         auto object = GPUAdapterImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(adapter, NativeType::GPUAdapter);
-        object->SetAlignedPointerInInternalField(0, adapter);
+        canvas::SetAlignedPointer(object, 0, adapter);
         adapter->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.cpp
@@ -25,7 +25,7 @@ void GPUAdapterInfoImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *i
 }
 
 GPUAdapterInfoImpl *GPUAdapterInfoImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -76,7 +76,7 @@ v8::Local<v8::FunctionTemplate> GPUAdapterInfoImpl::GetCtor(v8::Isolate *isolate
 void
 GPUAdapterInfoImpl::GetArchitecture(v8::Local<v8::Name> name,
                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
 
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
@@ -101,7 +101,7 @@ GPUAdapterInfoImpl::GetArchitecture(v8::Local<v8::Name> name,
 void
 GPUAdapterInfoImpl::GetDescription(v8::Local<v8::Name> name,
                                    const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
 
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
@@ -126,7 +126,7 @@ GPUAdapterInfoImpl::GetDescription(v8::Local<v8::Name> name,
 void
 GPUAdapterInfoImpl::GetDevice(v8::Local<v8::Name> name,
                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
 
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();
@@ -151,7 +151,7 @@ GPUAdapterInfoImpl::GetDevice(v8::Local<v8::Name> name,
 void
 GPUAdapterInfoImpl::GetVendor(v8::Local<v8::Name> name,
                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
 
     if (ptr == nullptr) {
         info.GetReturnValue().SetEmptyString();

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUAdapterInfoImpl.h
@@ -30,7 +30,7 @@ public:
         auto object = GPUAdapterInfoImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(info, NativeType::GPUAdapterInfo);
-        object->SetAlignedPointerInInternalField(0, info);
+        canvas::SetAlignedPointer(object, 0, info);
         info->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.cpp
@@ -26,7 +26,7 @@ void GPUBindGroupImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *iso
 }
 
 GPUBindGroupImpl *GPUBindGroupImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -61,7 +61,7 @@ v8::Local<v8::FunctionTemplate> GPUBindGroupImpl::GetCtor(v8::Isolate *isolate) 
 void
 GPUBindGroupImpl::GetLabel(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_bind_group_get_label(ptr->group_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUBindGroupImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(groupLayout, NativeType::GPUBindGroup);
-        object->SetAlignedPointerInInternalField(0, groupLayout);
+        canvas::SetAlignedPointer(object, 0, groupLayout);
         groupLayout->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.cpp
@@ -26,7 +26,7 @@ void GPUBindGroupLayoutImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolat
 }
 
 GPUBindGroupLayoutImpl *GPUBindGroupLayoutImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -61,7 +61,7 @@ v8::Local<v8::FunctionTemplate> GPUBindGroupLayoutImpl::GetCtor(v8::Isolate *iso
 void
 GPUBindGroupLayoutImpl::GetLabel(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_bind_group_layout_get_label(ptr->groupLayout_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBindGroupLayoutImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUBindGroupLayoutImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(groupLayout, NativeType::GPUBindGroupLayout);
-        object->SetAlignedPointerInInternalField(0, groupLayout);
+        canvas::SetAlignedPointer(object, 0, groupLayout);
         groupLayout->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.cpp
@@ -25,7 +25,7 @@ void GPUBufferImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolat
 }
 
 GPUBufferImpl *GPUBufferImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -90,7 +90,7 @@ v8::Local<v8::FunctionTemplate> GPUBufferImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUBufferImpl::GetUsage(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto usage = canvas_native_webgpu_buffer_usage(ptr->GetGPUBuffer());
         info.GetReturnValue().Set(
@@ -105,7 +105,7 @@ GPUBufferImpl::GetUsage(v8::Local<v8::Name> name,
 void
 GPUBufferImpl::GetSize(v8::Local<v8::Name> name,
                        const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto size = canvas_native_webgpu_buffer_size(ptr->GetGPUBuffer());
         info.GetReturnValue().Set((double) size);
@@ -259,7 +259,7 @@ void GPUBufferImpl::GetMappedRange(const v8::FunctionCallbackInfo<v8::Value> &ar
 void
 GPUBufferImpl::GetLabel(v8::Local<v8::Name> name,
                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_buffer_get_label(ptr->buffer_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUBufferImpl.h
@@ -30,7 +30,7 @@ public:
         auto object = GPUBufferImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(buffer, NativeType::GPUBuffer);
-        object->SetAlignedPointerInInternalField(0, buffer);
+        canvas::SetAlignedPointer(object, 0, buffer);
         buffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.cpp
@@ -9,10 +9,10 @@
 #include "GPUQueueImpl.h"
 
 v8::CFunction GPUCanvasContextImpl::fast_start_raf_(
-																										v8::CFunction::Make(GPUCanvasContextImpl::__FastStartRaf));
+																										CANVAS_FAST_FUNCTION(GPUCanvasContextImpl::__FastStartRaf));
 
 v8::CFunction GPUCanvasContextImpl::fast_stop_raf_(
-																									 v8::CFunction::Make(GPUCanvasContextImpl::__FastStopRaf));
+																									 CANVAS_FAST_FUNCTION(GPUCanvasContextImpl::__FastStopRaf));
 
 
 GPUCanvasContextImpl::GPUCanvasContextImpl(const CanvasGPUCanvasContext *context) : context_(
@@ -49,7 +49,7 @@ void GPUCanvasContextImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate 
 }
 
 GPUCanvasContextImpl *GPUCanvasContextImpl::GetPointer(const v8::Local<v8::Object> &object) {
-	auto ptr = object->GetAlignedPointerFromInternalField(0);
+	auto ptr = canvas::GetAlignedPointer(object, 0);
 	if (ptr == nullptr) {
 		return nullptr;
 	}
@@ -105,9 +105,9 @@ void GPUCanvasContextImpl::__StopRaf(const v8::FunctionCallbackInfo<v8::Value> &
 }
 
 
-void GPUCanvasContextImpl::GetContinuousRenderMode(v8::Local<v8::String> property,
+void GPUCanvasContextImpl::GetContinuousRenderMode(v8::Local<v8::Name> property,
 																									 const v8::PropertyCallbackInfo<v8::Value> &info) {
-	GPUCanvasContextImpl *ptr = GetPointer(info.This());
+	GPUCanvasContextImpl *ptr = GetPointer(canvas::Receiver(info));
 	if (ptr == nullptr) {
 		info.GetReturnValue().Set(false);
 		return;
@@ -115,10 +115,10 @@ void GPUCanvasContextImpl::GetContinuousRenderMode(v8::Local<v8::String> propert
 	info.GetReturnValue().Set(ptr->continuousRender_);
 }
 
-void GPUCanvasContextImpl::SetContinuousRenderMode(v8::Local<v8::String> property,
+void GPUCanvasContextImpl::SetContinuousRenderMode(v8::Local<v8::Name> property,
 																									 v8::Local<v8::Value> value,
 																									 const v8::PropertyCallbackInfo<void> &info) {
-	GPUCanvasContextImpl *ptr = GetPointer(info.This());
+	GPUCanvasContextImpl *ptr = GetPointer(canvas::Receiver(info));
 	if (ptr == nullptr) {
 		return;
 	}
@@ -182,7 +182,7 @@ v8::Local<v8::FunctionTemplate> GPUCanvasContextImpl::GetCtor(v8::Isolate *isola
 						ConvertToV8String(isolate, "__toDataURL"),
 						v8::FunctionTemplate::New(isolate, &__ToDataURL));
 	
-	tmpl->SetAccessor(ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
+	canvas::SetAccessor(tmpl, ConvertToV8String(isolate, "continuousRenderMode"), GetContinuousRenderMode,
 										SetContinuousRenderMode);
 	
 	cache->GPUCanvasContextTmpl =

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCanvasContextImpl.h
@@ -73,7 +73,7 @@ public:
 		auto object = GPUCanvasContextImpl::GetCtor(isolate)->GetFunction(
 																																			context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
 		SetNativeType(ctx, NativeType::GPUCanvasContext);
-		object->SetAlignedPointerInInternalField(0, ctx);
+		canvas::SetAlignedPointer(object, 0, ctx);
 		ctx->BindFinalizer(isolate, object);
 		return scope.Escape(object);
 	}
@@ -88,11 +88,11 @@ public:
 	
 	static void GetCapabilities(const v8::FunctionCallbackInfo<v8::Value> &args);
 	
-	static void SetContinuousRenderMode(v8::Local<v8::String> property,
+	static void SetContinuousRenderMode(v8::Local<v8::Name> property,
 																			v8::Local<v8::Value> value,
 																			const v8::PropertyCallbackInfo<void> &info);
 
-	static void GetContinuousRenderMode(v8::Local<v8::String> property,
+	static void GetContinuousRenderMode(v8::Local<v8::Name> property,
 																			const v8::PropertyCallbackInfo<v8::Value> &info);
 	
 	void SetRaf(std::shared_ptr<RafImpl> raf);

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.cpp
@@ -27,7 +27,7 @@ void GPUCommandBufferImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate 
 }
 
 GPUCommandBufferImpl *GPUCommandBufferImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -74,7 +74,7 @@ void GPUCommandBufferImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &ar
 void
 GPUCommandBufferImpl::GetLabel(v8::Local<v8::Name> name,
                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_command_buffer_get_label(ptr->commandBuffer_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandBufferImpl.h
@@ -34,7 +34,7 @@ public:
         auto object = GPUCommandBufferImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(commandBuffer, NativeType::GPUCommandBuffer);
-        object->SetAlignedPointerInInternalField(0, commandBuffer);
+        canvas::SetAlignedPointer(object, 0, commandBuffer);
         commandBuffer->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.cpp
@@ -33,7 +33,7 @@ void GPUCommandEncoderImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate
 }
 
 GPUCommandEncoderImpl *GPUCommandEncoderImpl::GetPointer(const v8::Local<v8::Object> &object) {
-	auto ptr = object->GetAlignedPointerFromInternalField(0);
+	auto ptr = canvas::GetAlignedPointer(object, 0);
 	if (ptr == nullptr) {
 		return nullptr;
 	}
@@ -131,7 +131,7 @@ void GPUCommandEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &a
 void
 GPUCommandEncoderImpl::GetLabel(v8::Local<v8::Name> name,
 																const v8::PropertyCallbackInfo<v8::Value> &info) {
-	auto ptr = GetPointer(info.This());
+	auto ptr = GetPointer(canvas::Receiver(info));
 	if (ptr != nullptr) {
 		auto label = canvas_native_webgpu_command_encoder_get_label(ptr->encoder_.get());
 		if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCommandEncoderImpl.h
@@ -33,7 +33,7 @@ public:
         auto object = GPUCommandEncoderImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(encoder, NativeType::GPUCommandEncoder);
-        object->SetAlignedPointerInInternalField(0, encoder);
+        canvas::SetAlignedPointer(object, 0, encoder);
         encoder->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.cpp
@@ -27,7 +27,7 @@ void GPUCompilationInfoImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolat
 }
 
 GPUCompilationInfoImpl *GPUCompilationInfoImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -65,7 +65,7 @@ GPUCompilationInfoImpl::GetMessages(v8::Local<v8::Name> name,
                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
     auto isolate = info.GetIsolate();
     auto context = isolate->GetCurrentContext();
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto count = canvas_native_webgpu_compilation_info_get_messages_count(
                 ptr->GetCompilationInfo());

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationInfoImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUCompilationInfoImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(info, NativeType::GPUCompilationInfo);
-        object->SetAlignedPointerInInternalField(0, info);
+        canvas::SetAlignedPointer(object, 0, info);
         info->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.cpp
@@ -29,7 +29,7 @@ void GPUCompilationMessageImpl::Init(v8::Local<v8::Object> canvasModule, v8::Iso
 
 GPUCompilationMessageImpl *
 GPUCompilationMessageImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -88,7 +88,7 @@ v8::Local<v8::FunctionTemplate> GPUCompilationMessageImpl::GetCtor(v8::Isolate *
 void
 GPUCompilationMessageImpl::GetLength(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto len = canvas_native_webgpu_compilation_message_get_length(ptr->GetMessage());
 
@@ -104,7 +104,7 @@ GPUCompilationMessageImpl::GetLength(v8::Local<v8::Name> name,
 void
 GPUCompilationMessageImpl::GetLineNum(v8::Local<v8::Name> name,
                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto num = canvas_native_webgpu_compilation_message_get_line_num(ptr->GetMessage());
 
@@ -120,7 +120,7 @@ GPUCompilationMessageImpl::GetLineNum(v8::Local<v8::Name> name,
 void
 GPUCompilationMessageImpl::GetLinePos(v8::Local<v8::Name> name,
                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto pos = canvas_native_webgpu_compilation_message_get_line_pos(ptr->GetMessage());
 
@@ -135,7 +135,7 @@ GPUCompilationMessageImpl::GetLinePos(v8::Local<v8::Name> name,
 void
 GPUCompilationMessageImpl::GetMessage(v8::Local<v8::Name> name,
                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto len = canvas_native_webgpu_compilation_message_get_message(ptr->GetMessage());
@@ -152,7 +152,7 @@ GPUCompilationMessageImpl::GetMessage(v8::Local<v8::Name> name,
 void
 GPUCompilationMessageImpl::GetOffset(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto offset = canvas_native_webgpu_compilation_message_get_offset(ptr->GetMessage());
 
@@ -168,7 +168,7 @@ GPUCompilationMessageImpl::GetOffset(v8::Local<v8::Name> name,
 void
 GPUCompilationMessageImpl::GetType(v8::Local<v8::Name> name,
                                    const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto message_type = canvas_native_webgpu_compilation_message_get_type(ptr->GetMessage());

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUCompilationMessageImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUCompilationMessageImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(message, NativeType::GPUCompilationMessage);
-        object->SetAlignedPointerInInternalField(0, message);
+        canvas::SetAlignedPointer(object, 0, message);
         message->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.cpp
@@ -32,7 +32,7 @@ void GPUComputePassEncoderImpl::Init(v8::Local<v8::Object> canvasModule, v8::Iso
 
 GPUComputePassEncoderImpl *
 GPUComputePassEncoderImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -111,7 +111,7 @@ void GPUComputePassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value
 void
 GPUComputePassEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_compute_pass_encoder_get_label(ptr->computePass_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePassEncoderImpl.h
@@ -33,7 +33,7 @@ public:
         auto object = GPUComputePassEncoderImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(pass, NativeType::GPUComputePass);
-        object->SetAlignedPointerInInternalField(0, pass);
+        canvas::SetAlignedPointer(object, 0, pass);
         pass->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.cpp
@@ -28,7 +28,7 @@ void GPUComputePipelineImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolat
 }
 
 GPUComputePipelineImpl *GPUComputePipelineImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -66,7 +66,7 @@ v8::Local<v8::FunctionTemplate> GPUComputePipelineImpl::GetCtor(v8::Isolate *iso
 void
 GPUComputePipelineImpl::GetLabel(v8::Local<v8::Name> name,
                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_compute_pipeline_get_label(ptr->pipeline_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUComputePipelineImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUComputePipelineImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(pipeline, NativeType::GPUComputePipeline);
-        object->SetAlignedPointerInInternalField(0, pipeline);
+        canvas::SetAlignedPointer(object, 0, pipeline);
         pipeline->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.cpp
@@ -43,7 +43,7 @@ void GPUDeviceImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolat
 }
 
 GPUDeviceImpl *GPUDeviceImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -171,7 +171,7 @@ v8::Local<v8::FunctionTemplate> GPUDeviceImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUDeviceImpl::GetLabel(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_device_get_label(ptr->device_.get());
         if (label == nullptr) {
@@ -269,7 +269,7 @@ GPUDeviceImpl::SetUncapturedError(const v8::FunctionCallbackInfo<v8::Value> &arg
 void
 GPUDeviceImpl::GetFeatures(v8::Local<v8::Name> name,
                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto context = isolate->GetCurrentContext();
@@ -302,7 +302,7 @@ GPUDeviceImpl::GetFeatures(v8::Local<v8::Name> name,
 void
 GPUDeviceImpl::GetLimits(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto limits = canvas_native_webgpu_device_get_limits(ptr->GetGPUDevice());
 
@@ -318,7 +318,7 @@ GPUDeviceImpl::GetLimits(v8::Local<v8::Name> name,
 void
 GPUDeviceImpl::GetQueue(v8::Local<v8::Name> name,
                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto queue = canvas_native_webgpu_device_get_queue(ptr->GetGPUDevice());
         auto ret = GPUQueueImpl::NewInstance(info.GetIsolate(),
@@ -338,7 +338,7 @@ struct LostData {
 void
 GPUDeviceImpl::GetLost(v8::Local<v8::Name> name,
                        const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     auto resolver = v8::Promise::Resolver::New(isolate->GetCurrentContext()).ToLocalChecked();
     info.GetReturnValue().Set(resolver->GetPromise());

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUDeviceImpl.h
@@ -30,7 +30,7 @@ public:
         auto object = GPUDeviceImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(device, NativeType::GPUDevice);
-        object->SetAlignedPointerInInternalField(0, device);
+        canvas::SetAlignedPointer(object, 0, device);
         device->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.cpp
@@ -25,7 +25,7 @@ void GPUImpl::Init(const v8::Local<v8::Object> &canvasModule, v8::Isolate *isola
 
 
 GPUImpl *GPUImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -67,7 +67,7 @@ void GPUImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
     auto object = new GPUImpl(instance);
 
-    ret->SetAlignedPointerInInternalField(0, object);
+    canvas::SetAlignedPointer(ret, 0, object);
 
     SetNativeType(object, NativeType::GPUInstance);
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUImpl.h
@@ -34,7 +34,7 @@ public:
         auto object = GPUImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(instance, NativeType::GPUInstance);
-        object->SetAlignedPointerInInternalField(0, instance);
+        canvas::SetAlignedPointer(object, 0, instance);
         instance->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.cpp
@@ -26,7 +26,7 @@ void GPUPipelineLayoutImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate
 }
 
 GPUPipelineLayoutImpl *GPUPipelineLayoutImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -61,7 +61,7 @@ v8::Local<v8::FunctionTemplate> GPUPipelineLayoutImpl::GetCtor(v8::Isolate *isol
 void
 GPUPipelineLayoutImpl::GetLabel(v8::Local<v8::Name> name,
                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_pipeline_layout_get_label(ptr->pipeline_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUPipelineLayoutImpl.h
@@ -32,7 +32,7 @@ public:
         auto object = GPUPipelineLayoutImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(pipeline, NativeType::GPUPipelineLayout);
-        object->SetAlignedPointerInInternalField(0, pipeline);
+        canvas::SetAlignedPointer(object, 0, pipeline);
         pipeline->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.cpp
@@ -25,7 +25,7 @@ void GPUQuerySetImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isol
 }
 
 GPUQuerySetImpl *GPUQuerySetImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -77,7 +77,7 @@ v8::Local<v8::FunctionTemplate> GPUQuerySetImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUQuerySetImpl::GetCount(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         info.GetReturnValue().Set(canvas_native_webgpu_query_set_get_count(ptr->GetQuerySet()));
         return;
@@ -90,7 +90,7 @@ GPUQuerySetImpl::GetCount(v8::Local<v8::Name> name,
 void
 GPUQuerySetImpl::GetType(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto type = canvas_native_webgpu_query_set_get_type(ptr->GetQuerySet());
@@ -111,7 +111,7 @@ GPUQuerySetImpl::GetType(v8::Local<v8::Name> name,
 void
 GPUQuerySetImpl::GetLabel(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     auto isolate = info.GetIsolate();
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_query_set_get_label(ptr->GetQuerySet());

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQuerySetImpl.h
@@ -29,7 +29,7 @@ public:
         auto object = GPUQuerySetImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(querySet, NativeType::GPUQuerySet);
-        object->SetAlignedPointerInInternalField(0, querySet);
+        canvas::SetAlignedPointer(object, 0, querySet);
         querySet->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.cpp
@@ -34,7 +34,7 @@ void GPUQueueImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isolate
 }
 
 GPUQueueImpl *GPUQueueImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -92,7 +92,7 @@ v8::Local<v8::FunctionTemplate> GPUQueueImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUQueueImpl::GetLabel(v8::Local<v8::Name> name,
                        const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_queue_get_label(ptr->queue_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUQueueImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUQueueImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(queue, NativeType::GPUQueue);
-        object->SetAlignedPointerInInternalField(0, queue);
+        canvas::SetAlignedPointer(object, 0, queue);
         queue->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.cpp
@@ -34,7 +34,7 @@ void GPURenderBundleEncoderImpl::Init(v8::Local<v8::Object> canvasModule, v8::Is
 
 GPURenderBundleEncoderImpl *
 GPURenderBundleEncoderImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -119,7 +119,7 @@ v8::Local<v8::FunctionTemplate> GPURenderBundleEncoderImpl::GetCtor(v8::Isolate 
 void
 GPURenderBundleEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_render_bundle_encoder_get_label(ptr->encoder_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleEncoderImpl.h
@@ -32,7 +32,7 @@ public:
         auto object = GPURenderBundleEncoderImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(encoder, NativeType::GPURenderBundleEncoder);
-        object->SetAlignedPointerInInternalField(0, encoder);
+        canvas::SetAlignedPointer(object, 0, encoder);
         encoder->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.cpp
@@ -26,7 +26,7 @@ void GPURenderBundleImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *
 }
 
 GPURenderBundleImpl *GPURenderBundleImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -60,7 +60,7 @@ v8::Local<v8::FunctionTemplate> GPURenderBundleImpl::GetCtor(v8::Isolate *isolat
 void
 GPURenderBundleImpl::GetLabel(v8::Local<v8::Name> name,
                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_render_bundle_get_label(ptr->bundle_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderBundleImpl.h
@@ -30,7 +30,7 @@ public:
         auto object = GPURenderBundleImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(bundle, NativeType::GPURenderBundle);
-        object->SetAlignedPointerInInternalField(0, bundle);
+        canvas::SetAlignedPointer(object, 0, bundle);
         bundle->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.cpp
@@ -33,7 +33,7 @@ void GPURenderPassEncoderImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isol
 
 GPURenderPassEncoderImpl *
 GPURenderPassEncoderImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -163,7 +163,7 @@ void GPURenderPassEncoderImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value>
 void
 GPURenderPassEncoderImpl::GetLabel(v8::Local<v8::Name> name,
                                    const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_render_pass_encoder_get_label(ptr->pass_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPassEncoderImpl.h
@@ -35,7 +35,7 @@ public:
         auto object = GPURenderPassEncoderImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(encoder, NativeType::GPURenderPassEncoder);
-        object->SetAlignedPointerInInternalField(0, encoder);
+        canvas::SetAlignedPointer(object, 0, encoder);
         encoder->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.cpp
@@ -27,7 +27,7 @@ void GPURenderPipelineImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate
 }
 
 GPURenderPipelineImpl *GPURenderPipelineImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -90,7 +90,7 @@ void GPURenderPipelineImpl::GetBindGroupLayout(const v8::FunctionCallbackInfo<v8
 void
 GPURenderPipelineImpl::GetLabel(v8::Local<v8::Name> name,
                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_render_pipeline_get_label(ptr->pipeline_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPURenderPipelineImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPURenderPipelineImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(pipeline, NativeType::GPURenderPipeline);
-        object->SetAlignedPointerInInternalField(0, pipeline);
+        canvas::SetAlignedPointer(object, 0, pipeline);
         pipeline->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.cpp
@@ -26,7 +26,7 @@ void GPUSamplerImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isola
 }
 
 GPUSamplerImpl *GPUSamplerImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -61,7 +61,7 @@ v8::Local<v8::FunctionTemplate> GPUSamplerImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUSamplerImpl::GetLabel(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_sampler_get_label(ptr->sampler_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSamplerImpl.h
@@ -30,7 +30,7 @@ public:
         auto object = GPUSamplerImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(sampler, NativeType::GPUSampler);
-        object->SetAlignedPointerInInternalField(0, sampler);
+        canvas::SetAlignedPointer(object, 0, sampler);
         sampler->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.cpp
@@ -27,7 +27,7 @@ void GPUShaderModuleImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *
 }
 
 GPUShaderModuleImpl *GPUShaderModuleImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -65,7 +65,7 @@ v8::Local<v8::FunctionTemplate> GPUShaderModuleImpl::GetCtor(v8::Isolate *isolat
 void
 GPUShaderModuleImpl::GetLabel(v8::Local<v8::Name> name,
                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_shader_module_get_label(ptr->shaderModule_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUShaderModuleImpl.h
@@ -31,7 +31,7 @@ public:
         auto object = GPUShaderModuleImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(shaderModule, NativeType::GPUShaderModule);
-        object->SetAlignedPointerInInternalField(0, shaderModule);
+        canvas::SetAlignedPointer(object, 0, shaderModule);
         shaderModule->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.cpp
@@ -26,7 +26,7 @@ void GPUSupportedLimitsImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolat
 }
 
 GPUSupportedLimitsImpl *GPUSupportedLimitsImpl::GetPointer(v8::Local<v8::Object> object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -47,226 +47,226 @@ v8::Local<v8::FunctionTemplate> GPUSupportedLimitsImpl::GetCtor(v8::Isolate *iso
     auto tmpl = ctorTmpl->InstanceTemplate();
     tmpl->SetInternalFieldCount(2);
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxTextureDimension1D"),
             GetMaxTextureDimension1D,
             SetMaxTextureDimension1D
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxTextureDimension2D"),
             GetMaxTextureDimension2D,
             SetMaxTextureDimension2D
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxTextureDimension3D"),
             GetMaxTextureDimension3D,
             SetMaxTextureDimension3D
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxTextureArrayLayers"),
             GetMaxTextureArrayLayers,
             SetMaxTextureArrayLayers
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxBindGroups"),
             GetMaxBindGroups,
             SetMaxBindGroups
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxBindingsPerBindGroup"),
             GetMaxBindingsPerBindGroup,
             SetMaxBindingsPerBindGroup
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxDynamicUniformBuffersPerPipelineLayout"),
             GetMaxDynamicUniformBuffersPerPipelineLayout,
             SetMaxDynamicUniformBuffersPerPipelineLayout
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxDynamicStorageBuffersPerPipelineLayout"),
             GetMaxDynamicStorageBuffersPerPipelineLayout,
             SetMaxDynamicStorageBuffersPerPipelineLayout
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxSampledTexturesPerShaderStage"),
             GetMaxSampledTexturesPerShaderStage,
             SetMaxSampledTexturesPerShaderStage
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxSamplersPerShaderStage"),
             GetMaxSamplersPerShaderStage,
             SetMaxSamplersPerShaderStage
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxStorageBuffersPerShaderStage"),
             GetMaxStorageBuffersPerShaderStage,
             SetMaxStorageBuffersPerShaderStage
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxStorageTexturesPerShaderStage"),
             GetMaxStorageTexturesPerShaderStage,
             SetMaxStorageTexturesPerShaderStage
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxUniformBuffersPerShaderStage"),
             GetMaxUniformBuffersPerShaderStage,
             SetMaxUniformBuffersPerShaderStage
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxUniformBufferBindingSize"),
             GetMaxUniformBufferBindingSize,
             SetMaxUniformBufferBindingSize
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxStorageBufferBindingSize"),
             GetMaxStorageBufferBindingSize,
             SetMaxStorageBufferBindingSize
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxVertexBuffers"),
             GetMaxVertexBuffers,
             SetMaxVertexBuffers
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxBufferSize"),
             GetMaxBufferSize,
             SetMaxBufferSize
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxVertexAttributes"),
             GetMaxVertexAttributes,
             SetMaxVertexAttributes
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxVertexBufferArrayStride"),
             GetMaxVertexBufferArrayStride,
             SetMaxVertexBufferArrayStride
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "minUniformBufferOffsetAlignment"),
             GetMinUniformBufferOffsetAlignment,
             SetMinUniformBufferOffsetAlignment
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "minStorageBufferOffsetAlignment"),
             GetMinStorageBufferOffsetAlignment,
             SetMinStorageBufferOffsetAlignment
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxInterStageShaderVariables"),
             GetMaxInterStageShaderComponents,
             SetMaxInterStageShaderComponents
     );
 
     // Legacy alias for older callers still using the old spec name
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxInterStageShaderComponents"),
             GetMaxInterStageShaderComponents,
             SetMaxInterStageShaderComponents
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxColorAttachments"),
             GetMaxColorAttachments,
             SetMaxColorAttachments
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxColorAttachmentBytesPerSample"),
             GetMaxColorAttachmentBytesPerSample,
             SetMaxColorAttachmentBytesPerSample
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeWorkgroupStorageSize"),
             GetMaxComputeWorkgroupStorageSize,
             SetMaxComputeWorkgroupStorageSize
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeInvocationsPerWorkgroup"),
             GetMaxComputeInvocationsPerWorkgroup,
             SetMaxComputeInvocationsPerWorkgroup
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeWorkgroupSizeX"),
             GetMaxComputeWorkgroupSizeX,
             SetMaxComputeWorkgroupSizeX
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeWorkgroupSizeY"),
             GetMaxComputeWorkgroupSizeY,
             SetMaxComputeWorkgroupSizeY
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeWorkgroupSizeZ"),
             GetMaxComputeWorkgroupSizeZ,
             SetMaxComputeWorkgroupSizeZ
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxComputeWorkgroupsPerDimension"),
             GetMaxComputeWorkgroupsPerDimension,
             SetMaxComputeWorkgroupsPerDimension
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "minSubgroupSize"),
             GetMinSubgroupSize,
             SetMinSubgroupSize
     );
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxSubgroupSize"),
             GetMaxSubgroupSize,
             SetMaxSubgroupSize
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxPushConstantSize"),
             GetMaxPushConstantSize,
             SetMaxPushConstantSize
     );
 
 
-    tmpl->SetAccessor(
+    canvas::SetAccessor(tmpl,
             ConvertToV8String(isolate, "maxNonSamplerBindings"),
             GetMaxNonSamplerBindings,
             SetMaxNonSamplerBindings
@@ -286,7 +286,7 @@ void GPUSupportedLimitsImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &arg
     auto limits = canvas_native_webgpu_create_limits();
     auto object = new GPUSupportedLimitsImpl(limits);
 
-    ret->SetAlignedPointerInInternalField(0, object);
+    canvas::SetAlignedPointer(ret, 0, object);
 
     SetNativeType(object, NativeType::GPUSupportedLimits);
 
@@ -296,9 +296,9 @@ void GPUSupportedLimitsImpl::Ctor(const v8::FunctionCallbackInfo<v8::Value> &arg
     return;
 }
 
-void GPUSupportedLimitsImpl::GetMaxTextureDimension1D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxTextureDimension1D(v8::Local<v8::Name> property,
                                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8192);
@@ -311,10 +311,10 @@ void GPUSupportedLimitsImpl::GetMaxTextureDimension1D(v8::Local<v8::String> prop
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxTextureDimension1D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxTextureDimension1D(v8::Local<v8::Name> property,
                                                       v8::Local<v8::Value> value,
                                                       const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -325,9 +325,9 @@ void GPUSupportedLimitsImpl::SetMaxTextureDimension1D(v8::Local<v8::String> prop
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxTextureDimension2D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxTextureDimension2D(v8::Local<v8::Name> property,
                                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8192);
@@ -340,10 +340,10 @@ void GPUSupportedLimitsImpl::GetMaxTextureDimension2D(v8::Local<v8::String> prop
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxTextureDimension2D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxTextureDimension2D(v8::Local<v8::Name> property,
                                                       v8::Local<v8::Value> value,
                                                       const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -354,9 +354,9 @@ void GPUSupportedLimitsImpl::SetMaxTextureDimension2D(v8::Local<v8::String> prop
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxTextureDimension3D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxTextureDimension3D(v8::Local<v8::Name> property,
                                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(2048);
@@ -368,10 +368,10 @@ void GPUSupportedLimitsImpl::GetMaxTextureDimension3D(v8::Local<v8::String> prop
     info.GetReturnValue().Set(limits->max_texture_dimension_3d);
 }
 
-void GPUSupportedLimitsImpl::SetMaxTextureDimension3D(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxTextureDimension3D(v8::Local<v8::Name> property,
                                                       v8::Local<v8::Value> value,
                                                       const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -382,9 +382,9 @@ void GPUSupportedLimitsImpl::SetMaxTextureDimension3D(v8::Local<v8::String> prop
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxTextureArrayLayers(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxTextureArrayLayers(v8::Local<v8::Name> property,
                                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -397,10 +397,10 @@ void GPUSupportedLimitsImpl::GetMaxTextureArrayLayers(v8::Local<v8::String> prop
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxTextureArrayLayers(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxTextureArrayLayers(v8::Local<v8::Name> property,
                                                       v8::Local<v8::Value> value,
                                                       const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -411,9 +411,9 @@ void GPUSupportedLimitsImpl::SetMaxTextureArrayLayers(v8::Local<v8::String> prop
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxBindGroups(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxBindGroups(v8::Local<v8::Name> property,
                                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(4);
@@ -426,10 +426,10 @@ void GPUSupportedLimitsImpl::GetMaxBindGroups(v8::Local<v8::String> property,
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxBindGroups(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxBindGroups(v8::Local<v8::Name> property,
                                               v8::Local<v8::Value> value,
                                               const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -440,9 +440,9 @@ void GPUSupportedLimitsImpl::SetMaxBindGroups(v8::Local<v8::String> property,
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxBindingsPerBindGroup(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxBindingsPerBindGroup(v8::Local<v8::Name> property,
                                                         const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(1000);
@@ -456,10 +456,10 @@ void GPUSupportedLimitsImpl::GetMaxBindingsPerBindGroup(v8::Local<v8::String> pr
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxBindingsPerBindGroup(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxBindingsPerBindGroup(v8::Local<v8::Name> property,
                                                         v8::Local<v8::Value> value,
                                                         const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -471,9 +471,9 @@ void GPUSupportedLimitsImpl::SetMaxBindingsPerBindGroup(v8::Local<v8::String> pr
 }
 
 void
-GPUSupportedLimitsImpl::GetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::String> property,
+GPUSupportedLimitsImpl::GetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8);
@@ -486,10 +486,10 @@ GPUSupportedLimitsImpl::GetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v
 }
 
 void
-GPUSupportedLimitsImpl::SetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::String> property,
+GPUSupportedLimitsImpl::SetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                                      v8::Local<v8::Value> value,
                                                                      const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -502,9 +502,9 @@ GPUSupportedLimitsImpl::SetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v
 }
 
 void
-GPUSupportedLimitsImpl::GetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::String> property,
+GPUSupportedLimitsImpl::GetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                                      const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(4);
@@ -517,10 +517,10 @@ GPUSupportedLimitsImpl::GetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v
 }
 
 void
-GPUSupportedLimitsImpl::SetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::String> property,
+GPUSupportedLimitsImpl::SetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                                      v8::Local<v8::Value> value,
                                                                      const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -532,9 +532,9 @@ GPUSupportedLimitsImpl::SetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxSampledTexturesPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxSampledTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(16);
@@ -546,10 +546,10 @@ void GPUSupportedLimitsImpl::GetMaxSampledTexturesPerShaderStage(v8::Local<v8::S
     info.GetReturnValue().Set(limits->max_sampled_textures_per_shader_stage);
 }
 
-void GPUSupportedLimitsImpl::SetMaxSampledTexturesPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxSampledTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                                  v8::Local<v8::Value> value,
                                                                  const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -562,9 +562,9 @@ void GPUSupportedLimitsImpl::SetMaxSampledTexturesPerShaderStage(v8::Local<v8::S
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxSamplersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxSamplersPerShaderStage(v8::Local<v8::Name> property,
                                                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(16);
@@ -577,10 +577,10 @@ void GPUSupportedLimitsImpl::GetMaxSamplersPerShaderStage(v8::Local<v8::String> 
 
 }
 
-void GPUSupportedLimitsImpl::SetMaxSamplersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxSamplersPerShaderStage(v8::Local<v8::Name> property,
                                                           v8::Local<v8::Value> value,
                                                           const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -592,9 +592,9 @@ void GPUSupportedLimitsImpl::SetMaxSamplersPerShaderStage(v8::Local<v8::String> 
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxStorageBuffersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxStorageBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8);
@@ -606,10 +606,10 @@ void GPUSupportedLimitsImpl::GetMaxStorageBuffersPerShaderStage(v8::Local<v8::St
     info.GetReturnValue().Set(limits->max_storage_buffers_per_shader_stage);
 }
 
-void GPUSupportedLimitsImpl::SetMaxStorageBuffersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxStorageBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                                 v8::Local<v8::Value> value,
                                                                 const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -621,9 +621,9 @@ void GPUSupportedLimitsImpl::SetMaxStorageBuffersPerShaderStage(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxStorageTexturesPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxStorageTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(4);
@@ -635,10 +635,10 @@ void GPUSupportedLimitsImpl::GetMaxStorageTexturesPerShaderStage(v8::Local<v8::S
     info.GetReturnValue().Set(limits->max_storage_textures_per_shader_stage);
 }
 
-void GPUSupportedLimitsImpl::SetMaxStorageTexturesPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxStorageTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                                  v8::Local<v8::Value> value,
                                                                  const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -651,9 +651,9 @@ void GPUSupportedLimitsImpl::SetMaxStorageTexturesPerShaderStage(v8::Local<v8::S
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxUniformBuffersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxUniformBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(12);
@@ -666,10 +666,10 @@ void GPUSupportedLimitsImpl::GetMaxUniformBuffersPerShaderStage(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxUniformBuffersPerShaderStage(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxUniformBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                                 v8::Local<v8::Value> value,
                                                                 const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -680,9 +680,9 @@ void GPUSupportedLimitsImpl::SetMaxUniformBuffersPerShaderStage(v8::Local<v8::St
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxUniformBufferBindingSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxUniformBufferBindingSize(v8::Local<v8::Name> property,
                                                             const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(64);
@@ -695,10 +695,10 @@ void GPUSupportedLimitsImpl::GetMaxUniformBufferBindingSize(v8::Local<v8::String
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxUniformBufferBindingSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxUniformBufferBindingSize(v8::Local<v8::Name> property,
                                                             v8::Local<v8::Value> value,
                                                             const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -709,9 +709,9 @@ void GPUSupportedLimitsImpl::SetMaxUniformBufferBindingSize(v8::Local<v8::String
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxStorageBufferBindingSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxStorageBufferBindingSize(v8::Local<v8::Name> property,
                                                             const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(128);
@@ -724,10 +724,10 @@ void GPUSupportedLimitsImpl::GetMaxStorageBufferBindingSize(v8::Local<v8::String
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxStorageBufferBindingSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxStorageBufferBindingSize(v8::Local<v8::Name> property,
                                                             v8::Local<v8::Value> value,
                                                             const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -738,9 +738,9 @@ void GPUSupportedLimitsImpl::SetMaxStorageBufferBindingSize(v8::Local<v8::String
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxVertexBuffers(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxVertexBuffers(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8);
@@ -753,10 +753,10 @@ void GPUSupportedLimitsImpl::GetMaxVertexBuffers(v8::Local<v8::String> property,
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxVertexBuffers(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxVertexBuffers(v8::Local<v8::Name> property,
                                                  v8::Local<v8::Value> value,
                                                  const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -767,9 +767,9 @@ void GPUSupportedLimitsImpl::SetMaxVertexBuffers(v8::Local<v8::String> property,
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxBufferSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxBufferSize(v8::Local<v8::Name> property,
                                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -783,10 +783,10 @@ void GPUSupportedLimitsImpl::GetMaxBufferSize(v8::Local<v8::String> property,
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxBufferSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxBufferSize(v8::Local<v8::Name> property,
                                               v8::Local<v8::Value> value,
                                               const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -798,9 +798,9 @@ void GPUSupportedLimitsImpl::SetMaxBufferSize(v8::Local<v8::String> property,
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxVertexAttributes(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxVertexAttributes(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(16);
@@ -813,10 +813,10 @@ void GPUSupportedLimitsImpl::GetMaxVertexAttributes(v8::Local<v8::String> proper
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxVertexAttributes(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxVertexAttributes(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -828,9 +828,9 @@ void GPUSupportedLimitsImpl::SetMaxVertexAttributes(v8::Local<v8::String> proper
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxVertexBufferArrayStride(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxVertexBufferArrayStride(v8::Local<v8::Name> property,
                                                            const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(2048);
@@ -844,10 +844,10 @@ void GPUSupportedLimitsImpl::GetMaxVertexBufferArrayStride(v8::Local<v8::String>
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxVertexBufferArrayStride(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxVertexBufferArrayStride(v8::Local<v8::Name> property,
                                                            v8::Local<v8::Value> value,
                                                            const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -859,9 +859,9 @@ void GPUSupportedLimitsImpl::SetMaxVertexBufferArrayStride(v8::Local<v8::String>
 }
 
 
-void GPUSupportedLimitsImpl::GetMinUniformBufferOffsetAlignment(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMinUniformBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -875,10 +875,10 @@ void GPUSupportedLimitsImpl::GetMinUniformBufferOffsetAlignment(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::SetMinUniformBufferOffsetAlignment(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMinUniformBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                                 v8::Local<v8::Value> value,
                                                                 const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -890,9 +890,9 @@ void GPUSupportedLimitsImpl::SetMinUniformBufferOffsetAlignment(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::GetMinStorageBufferOffsetAlignment(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMinStorageBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -906,10 +906,10 @@ void GPUSupportedLimitsImpl::GetMinStorageBufferOffsetAlignment(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::SetMinStorageBufferOffsetAlignment(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMinStorageBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                                 v8::Local<v8::Value> value,
                                                                 const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -921,9 +921,9 @@ void GPUSupportedLimitsImpl::SetMinStorageBufferOffsetAlignment(v8::Local<v8::St
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxInterStageShaderComponents(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxInterStageShaderComponents(v8::Local<v8::Name> property,
                                                               const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(60);
@@ -937,10 +937,10 @@ void GPUSupportedLimitsImpl::GetMaxInterStageShaderComponents(v8::Local<v8::Stri
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxInterStageShaderComponents(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxInterStageShaderComponents(v8::Local<v8::Name> property,
                                                               v8::Local<v8::Value> value,
                                                               const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -952,9 +952,9 @@ void GPUSupportedLimitsImpl::SetMaxInterStageShaderComponents(v8::Local<v8::Stri
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxColorAttachments(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxColorAttachments(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(8);
@@ -968,10 +968,10 @@ void GPUSupportedLimitsImpl::GetMaxColorAttachments(v8::Local<v8::String> proper
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxColorAttachments(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxColorAttachments(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -983,9 +983,9 @@ void GPUSupportedLimitsImpl::SetMaxColorAttachments(v8::Local<v8::String> proper
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxColorAttachmentBytesPerSample(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxColorAttachmentBytesPerSample(v8::Local<v8::Name> property,
                                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(32);
@@ -998,10 +998,10 @@ void GPUSupportedLimitsImpl::GetMaxColorAttachmentBytesPerSample(v8::Local<v8::S
 
 }
 
-void GPUSupportedLimitsImpl::SetMaxColorAttachmentBytesPerSample(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxColorAttachmentBytesPerSample(v8::Local<v8::Name> property,
                                                                  v8::Local<v8::Value> value,
                                                                  const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1014,9 +1014,9 @@ void GPUSupportedLimitsImpl::SetMaxColorAttachmentBytesPerSample(v8::Local<v8::S
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupStorageSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupStorageSize(v8::Local<v8::Name> property,
                                                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(16384);
@@ -1029,10 +1029,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupStorageSize(v8::Local<v8::Str
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupStorageSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupStorageSize(v8::Local<v8::Name> property,
                                                                v8::Local<v8::Value> value,
                                                                const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1044,9 +1044,9 @@ void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupStorageSize(v8::Local<v8::Str
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::Name> property,
                                                                   const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -1059,10 +1059,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::Name> property,
                                                                   v8::Local<v8::Value> value,
                                                                   const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1074,9 +1074,9 @@ void GPUSupportedLimitsImpl::SetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeX(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeX(v8::Local<v8::Name> property,
                                                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -1089,10 +1089,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeX(v8::Local<v8::String> p
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeX(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeX(v8::Local<v8::Name> property,
                                                          v8::Local<v8::Value> value,
                                                          const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1104,9 +1104,9 @@ void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeX(v8::Local<v8::String> p
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeY(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeY(v8::Local<v8::Name> property,
                                                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(256);
@@ -1119,10 +1119,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeY(v8::Local<v8::String> p
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeY(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeY(v8::Local<v8::Name> property,
                                                          v8::Local<v8::Value> value,
                                                          const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1134,9 +1134,9 @@ void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeY(v8::Local<v8::String> p
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeZ(v8::Local<v8::Name> property,
                                                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(64);
@@ -1149,10 +1149,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> p
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeZ(v8::Local<v8::Name> property,
                                                          v8::Local<v8::Value> value,
                                                          const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1163,9 +1163,9 @@ void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> p
     }
 }
 
-void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupsPerDimension(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupsPerDimension(v8::Local<v8::Name> property,
                                                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(65535);
@@ -1178,10 +1178,10 @@ void GPUSupportedLimitsImpl::GetMaxComputeWorkgroupsPerDimension(v8::Local<v8::S
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupsPerDimension(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupsPerDimension(v8::Local<v8::Name> property,
                                                                  v8::Local<v8::Value> value,
                                                                  const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }
@@ -1192,46 +1192,46 @@ void GPUSupportedLimitsImpl::SetMaxComputeWorkgroupsPerDimension(v8::Local<v8::S
     }
 }
 
-void GPUSupportedLimitsImpl::GetMinSubgroupSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMinSubgroupSize(v8::Local<v8::Name> property,
                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
     info.GetReturnValue().Set(0);
 }
 
 
-void GPUSupportedLimitsImpl::SetMinSubgroupSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMinSubgroupSize(v8::Local<v8::Name> property,
                                                 v8::Local<v8::Value> value,
                                                 const v8::PropertyCallbackInfo<void> &info) {
     // min_subgroup_size no longer exists in CanvasGPUSupportedLimits
 }
 
-void GPUSupportedLimitsImpl::GetMaxSubgroupSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxSubgroupSize(v8::Local<v8::Name> property,
                                                 const v8::PropertyCallbackInfo<v8::Value> &info) {
     info.GetReturnValue().Set(0);
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxSubgroupSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxSubgroupSize(v8::Local<v8::Name> property,
                                                 v8::Local<v8::Value> value,
                                                 const v8::PropertyCallbackInfo<void> &info) {
     // max_subgroup_size no longer exists in CanvasGPUSupportedLimits
 }
 
 
-void GPUSupportedLimitsImpl::GetMaxPushConstantSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxPushConstantSize(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info) {
     info.GetReturnValue().Set(0);
 }
 
 
-void GPUSupportedLimitsImpl::SetMaxPushConstantSize(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxPushConstantSize(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info) {
     // max_push_constant_size no longer exists in CanvasGPUSupportedLimits
 }
 
-void GPUSupportedLimitsImpl::GetMaxNonSamplerBindings(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::GetMaxNonSamplerBindings(v8::Local<v8::Name> property,
                                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         // return default ??
         info.GetReturnValue().Set(1000000);
@@ -1244,10 +1244,10 @@ void GPUSupportedLimitsImpl::GetMaxNonSamplerBindings(v8::Local<v8::String> prop
 
 }
 
-void GPUSupportedLimitsImpl::SetMaxNonSamplerBindings(v8::Local<v8::String> property,
+void GPUSupportedLimitsImpl::SetMaxNonSamplerBindings(v8::Local<v8::Name> property,
                                                       v8::Local<v8::Value> value,
                                                       const v8::PropertyCallbackInfo<void> &info) {
-    GPUSupportedLimitsImpl *ptr = GetPointer(info.This());
+    GPUSupportedLimitsImpl *ptr = GetPointer(canvas::Receiver(info));
     if (ptr == nullptr) {
         return;
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUSupportedLimitsImpl.h
@@ -23,7 +23,7 @@ public:
         auto object = GPUSupportedLimitsImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(limits, NativeType::GPUSupportedLimits);
-        object->SetAlignedPointerInInternalField(0, limits);
+        canvas::SetAlignedPointer(object, 0, limits);
         limits->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }
@@ -36,246 +36,246 @@ public:
 
     static void Ctor(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-    static void GetMaxTextureDimension1D(v8::Local<v8::String> property,
+    static void GetMaxTextureDimension1D(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxTextureDimension1D(v8::Local<v8::String> property,
+    static void SetMaxTextureDimension1D(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxTextureDimension2D(v8::Local<v8::String> property,
+    static void GetMaxTextureDimension2D(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxTextureDimension2D(v8::Local<v8::String> property,
+    static void SetMaxTextureDimension2D(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxTextureDimension3D(v8::Local<v8::String> property,
+    static void GetMaxTextureDimension3D(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxTextureDimension3D(v8::Local<v8::String> property,
+    static void SetMaxTextureDimension3D(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxTextureArrayLayers(v8::Local<v8::String> property,
+    static void GetMaxTextureArrayLayers(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxTextureArrayLayers(v8::Local<v8::String> property,
+    static void SetMaxTextureArrayLayers(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxBindGroups(v8::Local<v8::String> property,
+    static void GetMaxBindGroups(v8::Local<v8::Name> property,
                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxBindGroups(v8::Local<v8::String> property,
+    static void SetMaxBindGroups(v8::Local<v8::Name> property,
                                  v8::Local<v8::Value> value,
                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxBindingsPerBindGroup(v8::Local<v8::String> property,
+    static void GetMaxBindingsPerBindGroup(v8::Local<v8::Name> property,
                                            const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxBindingsPerBindGroup(v8::Local<v8::String> property,
+    static void SetMaxBindingsPerBindGroup(v8::Local<v8::Name> property,
                                            v8::Local<v8::Value> value,
                                            const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::String> property,
+    static void GetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::String> property,
+    static void SetMaxDynamicUniformBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                              v8::Local<v8::Value> value,
                                                              const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::String> property,
+    static void GetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::String> property,
+    static void SetMaxDynamicStorageBuffersPerPipelineLayout(v8::Local<v8::Name> property,
                                                              v8::Local<v8::Value> value,
                                                              const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxSampledTexturesPerShaderStage(v8::Local<v8::String> property,
+    static void GetMaxSampledTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxSampledTexturesPerShaderStage(v8::Local<v8::String> property,
+    static void SetMaxSampledTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxSamplersPerShaderStage(v8::Local<v8::String> property,
+    static void GetMaxSamplersPerShaderStage(v8::Local<v8::Name> property,
                                              const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxSamplersPerShaderStage(v8::Local<v8::String> property,
+    static void SetMaxSamplersPerShaderStage(v8::Local<v8::Name> property,
                                              v8::Local<v8::Value> value,
                                              const v8::PropertyCallbackInfo<void> &info);
 
 
-    static void GetMaxStorageBuffersPerShaderStage(v8::Local<v8::String> property,
+    static void GetMaxStorageBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxStorageBuffersPerShaderStage(v8::Local<v8::String> property,
+    static void SetMaxStorageBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                    v8::Local<v8::Value> value,
                                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxStorageTexturesPerShaderStage(v8::Local<v8::String> property,
+    static void GetMaxStorageTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxStorageTexturesPerShaderStage(v8::Local<v8::String> property,
+    static void SetMaxStorageTexturesPerShaderStage(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxUniformBuffersPerShaderStage(v8::Local<v8::String> property,
+    static void GetMaxUniformBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxUniformBuffersPerShaderStage(v8::Local<v8::String> property,
+    static void SetMaxUniformBuffersPerShaderStage(v8::Local<v8::Name> property,
                                                    v8::Local<v8::Value> value,
                                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxUniformBufferBindingSize(v8::Local<v8::String> property,
+    static void GetMaxUniformBufferBindingSize(v8::Local<v8::Name> property,
                                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxUniformBufferBindingSize(v8::Local<v8::String> property,
+    static void SetMaxUniformBufferBindingSize(v8::Local<v8::Name> property,
                                                v8::Local<v8::Value> value,
                                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxStorageBufferBindingSize(v8::Local<v8::String> property,
+    static void GetMaxStorageBufferBindingSize(v8::Local<v8::Name> property,
                                                const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxStorageBufferBindingSize(v8::Local<v8::String> property,
+    static void SetMaxStorageBufferBindingSize(v8::Local<v8::Name> property,
                                                v8::Local<v8::Value> value,
                                                const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxVertexBuffers(v8::Local<v8::String> property,
+    static void GetMaxVertexBuffers(v8::Local<v8::Name> property,
                                     const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxVertexBuffers(v8::Local<v8::String> property,
+    static void SetMaxVertexBuffers(v8::Local<v8::Name> property,
                                     v8::Local<v8::Value> value,
                                     const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxBufferSize(v8::Local<v8::String> property,
+    static void GetMaxBufferSize(v8::Local<v8::Name> property,
                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxBufferSize(v8::Local<v8::String> property,
+    static void SetMaxBufferSize(v8::Local<v8::Name> property,
                                  v8::Local<v8::Value> value,
                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxVertexAttributes(v8::Local<v8::String> property,
+    static void GetMaxVertexAttributes(v8::Local<v8::Name> property,
                                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxVertexAttributes(v8::Local<v8::String> property,
+    static void SetMaxVertexAttributes(v8::Local<v8::Name> property,
                                        v8::Local<v8::Value> value,
                                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxVertexBufferArrayStride(v8::Local<v8::String> property,
+    static void GetMaxVertexBufferArrayStride(v8::Local<v8::Name> property,
                                               const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxVertexBufferArrayStride(v8::Local<v8::String> property,
+    static void SetMaxVertexBufferArrayStride(v8::Local<v8::Name> property,
                                               v8::Local<v8::Value> value,
                                               const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMinUniformBufferOffsetAlignment(v8::Local<v8::String> property,
+    static void GetMinUniformBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMinUniformBufferOffsetAlignment(v8::Local<v8::String> property,
+    static void SetMinUniformBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                    v8::Local<v8::Value> value,
                                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMinStorageBufferOffsetAlignment(v8::Local<v8::String> property,
+    static void GetMinStorageBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMinStorageBufferOffsetAlignment(v8::Local<v8::String> property,
+    static void SetMinStorageBufferOffsetAlignment(v8::Local<v8::Name> property,
                                                    v8::Local<v8::Value> value,
                                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxInterStageShaderComponents(v8::Local<v8::String> property,
+    static void GetMaxInterStageShaderComponents(v8::Local<v8::Name> property,
                                                  const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxInterStageShaderComponents(v8::Local<v8::String> property,
+    static void SetMaxInterStageShaderComponents(v8::Local<v8::Name> property,
                                                  v8::Local<v8::Value> value,
                                                  const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxColorAttachments(v8::Local<v8::String> property,
+    static void GetMaxColorAttachments(v8::Local<v8::Name> property,
                                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxColorAttachments(v8::Local<v8::String> property,
+    static void SetMaxColorAttachments(v8::Local<v8::Name> property,
                                        v8::Local<v8::Value> value,
                                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxColorAttachmentBytesPerSample(v8::Local<v8::String> property,
+    static void GetMaxColorAttachmentBytesPerSample(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxColorAttachmentBytesPerSample(v8::Local<v8::String> property,
+    static void SetMaxColorAttachmentBytesPerSample(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeWorkgroupStorageSize(v8::Local<v8::String> property,
+    static void GetMaxComputeWorkgroupStorageSize(v8::Local<v8::Name> property,
                                                   const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxComputeWorkgroupStorageSize(v8::Local<v8::String> property,
+    static void SetMaxComputeWorkgroupStorageSize(v8::Local<v8::Name> property,
                                                   v8::Local<v8::Value> value,
                                                   const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::String> property,
+    static void GetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::Name> property,
                                                      const v8::PropertyCallbackInfo<v8::Value> &info);
 
 
-    static void SetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::String> property,
+    static void SetMaxComputeInvocationsPerWorkgroup(v8::Local<v8::Name> property,
                                                      v8::Local<v8::Value> value,
                                                      const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeWorkgroupSizeX(v8::Local<v8::String> property,
+    static void GetMaxComputeWorkgroupSizeX(v8::Local<v8::Name> property,
                                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxComputeWorkgroupSizeX(v8::Local<v8::String> property,
+    static void SetMaxComputeWorkgroupSizeX(v8::Local<v8::Name> property,
                                             v8::Local<v8::Value> value,
                                             const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeWorkgroupSizeY(v8::Local<v8::String> property,
+    static void GetMaxComputeWorkgroupSizeY(v8::Local<v8::Name> property,
                                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxComputeWorkgroupSizeY(v8::Local<v8::String> property,
+    static void SetMaxComputeWorkgroupSizeY(v8::Local<v8::Name> property,
                                             v8::Local<v8::Value> value,
                                             const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> property,
+    static void GetMaxComputeWorkgroupSizeZ(v8::Local<v8::Name> property,
                                             const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxComputeWorkgroupSizeZ(v8::Local<v8::String> property,
+    static void SetMaxComputeWorkgroupSizeZ(v8::Local<v8::Name> property,
                                             v8::Local<v8::Value> value,
                                             const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxComputeWorkgroupsPerDimension(v8::Local<v8::String> property,
+    static void GetMaxComputeWorkgroupsPerDimension(v8::Local<v8::Name> property,
                                                     const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxComputeWorkgroupsPerDimension(v8::Local<v8::String> property,
+    static void SetMaxComputeWorkgroupsPerDimension(v8::Local<v8::Name> property,
                                                     v8::Local<v8::Value> value,
                                                     const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMinSubgroupSize(v8::Local<v8::String> property,
+    static void GetMinSubgroupSize(v8::Local<v8::Name> property,
                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMinSubgroupSize(v8::Local<v8::String> property,
+    static void SetMinSubgroupSize(v8::Local<v8::Name> property,
                                    v8::Local<v8::Value> value,
                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxSubgroupSize(v8::Local<v8::String> property,
+    static void GetMaxSubgroupSize(v8::Local<v8::Name> property,
                                    const v8::PropertyCallbackInfo<v8::Value> &info);
 
-    static void SetMaxSubgroupSize(v8::Local<v8::String> property,
+    static void SetMaxSubgroupSize(v8::Local<v8::Name> property,
                                    v8::Local<v8::Value> value,
                                    const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxPushConstantSize(v8::Local<v8::String> property,
+    static void GetMaxPushConstantSize(v8::Local<v8::Name> property,
                                        const v8::PropertyCallbackInfo<v8::Value> &info);
 
 
-    static void SetMaxPushConstantSize(v8::Local<v8::String> property,
+    static void SetMaxPushConstantSize(v8::Local<v8::Name> property,
                                        v8::Local<v8::Value> value,
                                        const v8::PropertyCallbackInfo<void> &info);
 
-    static void GetMaxNonSamplerBindings(v8::Local<v8::String> property,
+    static void GetMaxNonSamplerBindings(v8::Local<v8::Name> property,
                                          const v8::PropertyCallbackInfo<v8::Value> &info);
 
 
-    static void SetMaxNonSamplerBindings(v8::Local<v8::String> property,
+    static void SetMaxNonSamplerBindings(v8::Local<v8::Name> property,
                                          v8::Local<v8::Value> value,
                                          const v8::PropertyCallbackInfo<void> &info);
 

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.cpp
@@ -27,7 +27,7 @@ void GPUTextureImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *isola
 }
 
 GPUTextureImpl *GPUTextureImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -120,7 +120,7 @@ v8::Local<v8::FunctionTemplate> GPUTextureImpl::GetCtor(v8::Isolate *isolate) {
 void
 GPUTextureImpl::GetLabel(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_texture_get_label(ptr->texture_.get());
         if (label == nullptr) {
@@ -140,7 +140,7 @@ GPUTextureImpl::GetLabel(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetDimension(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto width = canvas_native_webgpu_texture_get_dimension(ptr->GetTexture());
         auto isolate = info.GetIsolate();
@@ -164,7 +164,7 @@ GPUTextureImpl::GetDimension(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetWidth(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto width = canvas_native_webgpu_texture_get_width(ptr->GetTexture());
         info.GetReturnValue().Set(width);
@@ -177,7 +177,7 @@ GPUTextureImpl::GetWidth(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetHeight(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto value = canvas_native_webgpu_texture_get_height(ptr->GetTexture());
         info.GetReturnValue().Set(value);
@@ -189,7 +189,7 @@ GPUTextureImpl::GetHeight(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetDepthOrArrayLayers(v8::Local<v8::Name> name,
                                       const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto value = canvas_native_webgpu_texture_get_depth_or_array_layers(ptr->GetTexture());
         info.GetReturnValue().Set(value);
@@ -202,7 +202,7 @@ GPUTextureImpl::GetDepthOrArrayLayers(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetUsage(v8::Local<v8::Name> name,
                          const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto value = canvas_native_webgpu_texture_get_usage(ptr->GetTexture());
         info.GetReturnValue().Set(value);
@@ -215,7 +215,7 @@ GPUTextureImpl::GetUsage(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetFormat(v8::Local<v8::Name> name,
                           const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto isolate = info.GetIsolate();
         auto value = canvas_native_webgpu_texture_get_format(ptr->GetTexture());
@@ -229,7 +229,7 @@ GPUTextureImpl::GetFormat(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetSampleCount(v8::Local<v8::Name> name,
                                const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto value = canvas_native_webgpu_texture_get_sample_count(ptr->GetTexture());
         info.GetReturnValue().Set(value);
@@ -241,7 +241,7 @@ GPUTextureImpl::GetSampleCount(v8::Local<v8::Name> name,
 void
 GPUTextureImpl::GetMipLevelCount(v8::Local<v8::Name> name,
                                  const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto value = canvas_native_webgpu_texture_get_mip_level_count(ptr->GetTexture());
         info.GetReturnValue().Set(value);

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureImpl.h
@@ -33,7 +33,7 @@ public:
         auto object = GPUTextureImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(texture, NativeType::GPUTexture);
-        object->SetAlignedPointerInInternalField(0, texture);
+        canvas::SetAlignedPointer(object, 0, texture);
         texture->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.cpp
@@ -25,7 +25,7 @@ void GPUTextureViewImpl::Init(v8::Local<v8::Object> canvasModule, v8::Isolate *i
 }
 
 GPUTextureViewImpl *GPUTextureViewImpl::GetPointer(const v8::Local<v8::Object> &object) {
-    auto ptr = object->GetAlignedPointerFromInternalField(0);
+    auto ptr = canvas::GetAlignedPointer(object, 0);
     if (ptr == nullptr) {
         return nullptr;
     }
@@ -72,7 +72,7 @@ void GPUTextureViewImpl::Destroy(const v8::FunctionCallbackInfo<v8::Value> &args
 void
 GPUTextureViewImpl::GetLabel(v8::Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value> &info) {
-    auto ptr = GetPointer(info.This());
+    auto ptr = GetPointer(canvas::Receiver(info));
     if (ptr != nullptr) {
         auto label = canvas_native_webgpu_texture_view_get_label(ptr->view_.get());
         if (label == nullptr) {

--- a/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
+++ b/packages/canvas/platforms/ios/src/cpp/webgpu/GPUTextureViewImpl.h
@@ -33,7 +33,7 @@ public:
         auto object = GPUTextureViewImpl::GetCtor(isolate)->GetFunction(
                 context).ToLocalChecked()->NewInstance(context).ToLocalChecked();
         SetNativeType(view, NativeType::GPUTextureView);
-        object->SetAlignedPointerInInternalField(0, view);
+        canvas::SetAlignedPointer(object, 0, view);
         view->BindFinalizer(isolate, object);
         return scope.Escape(object);
     }

--- a/tools/tests/check-apple-v8.py
+++ b/tools/tests/check-apple-v8.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Syntax-check every Apple bridge source against a selected runtime framework."""
+import argparse
+import concurrent.futures
+from pathlib import Path
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--runtime-framework', type=Path, required=True, help='Path to NativeScript.framework')
+parser.add_argument('--canvas-framework', type=Path, required=True, help='Path to CanvasNative.framework')
+parser.add_argument('--sdk', default='iphonesimulator')
+parser.add_argument('--target', default='arm64-apple-ios13.0-simulator')
+parser.add_argument('--jobs', type=int, default=4)
+args = parser.parse_args()
+root = Path(__file__).resolve().parents[2]
+src = root / 'packages/canvas/platforms/ios/src'
+for framework in [args.runtime_framework, args.canvas_framework]:
+    if not framework.is_dir():
+        parser.error(f'Framework does not exist: {framework}')
+sdk = subprocess.check_output(['xcrun', '--sdk', args.sdk, '--show-sdk-path'], text=True).strip()
+command = ['xcrun', 'clang++', '-fsyntax-only', '-std=c++20', '-x', 'objective-c++', '-target', args.target, '-isysroot', sdk]
+for framework in [args.runtime_framework, args.canvas_framework]:
+    command += ['-F', str(framework.resolve().parent)]
+command += ['-I', str(args.runtime_framework.resolve() / 'Headers/include'), '-I', str(args.runtime_framework.resolve() / 'Headers')]
+for directory in [src, *sorted(p for p in src.rglob('*') if p.is_dir())]:
+    command += ['-I', str(directory)]
+files = sorted([*src.rglob('*.cpp'), *src.glob('*.mm')])
+def check(source):
+    result = subprocess.run(command + [str(source)], capture_output=True, text=True)
+    return source.relative_to(src), result
+failed = 0
+with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+    for source, result in pool.map(check, files):
+        print(f'{source}: {"FAIL" if result.returncode else "PASS"}', flush=True)
+        if result.returncode:
+            failed += 1
+            print(result.stderr, file=sys.stderr)
+print(f'{len(files) - failed}/{len(files)} translation units passed')
+sys.exit(bool(failed))


### PR DESCRIPTION
Adapt the Apple Canvas bridge to V8 14.9 while retaining V8 10 compatibility: tagged pointers, receiver/accessor APIs, UTF-8 APIs and the removed fast typed-array interface. Use the existing ordinary callbacks where newer V8 no longer exposes that fast API.

## Validation

All 59 Apple bridge translation units passed syntax checks against both V8 10 and V8 14 framework headers. The source-built V8 14.9 tvOS app passes Canvas pixel/Unicode metrics, WebGL typed-buffer/readback and WebGPU compute tests. The mapping-progress regression separately requires #148. JIT-enabled iOS fast-path performance has not been benchmarked.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `ed84b43758e24751f2bc60a9a9a888ed944a1776`, changing 128 files against `1fd6ef470dfdfd43b3385fa7ef43feddd1debd06`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
