### PR TITLE
fix(webgpu): progress buffer mappings without a render loop

### DIFF
--- a/crates/canvas-c/src/webgpu/gpu_buffer.rs
+++ b/crates/canvas-c/src/webgpu/gpu_buffer.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{mpsc, Arc, OnceLock};
 use std::{
     borrow::Cow,
     ffi::CString,
@@ -9,6 +9,25 @@ use crate::webgpu::error::{handle_error_fatal, CanvasGPUError, CanvasGPUErrorTyp
 use crate::webgpu::prelude::label_to_ptr;
 
 use super::gpu::CanvasWebGPUInstance;
+
+// wgpu requires polling to dispatch completed mappings, including compute-only
+// workloads with no canvas/frame loop. One worker services requests off the UI
+// thread and retains each instance until its pending callbacks have run.
+fn poll_mappings(instance: Arc<CanvasWebGPUInstance>) {
+    static POLLER: OnceLock<mpsc::Sender<Arc<CanvasWebGPUInstance>>> = OnceLock::new();
+    let sender = POLLER.get_or_init(|| {
+        let (sender, receiver) = mpsc::channel::<Arc<CanvasWebGPUInstance>>();
+        std::thread::spawn(move || {
+            for instance in receiver {
+                if let Err(error) = instance.global().poll_all_devices(true) {
+                    log::error!("WebGPU mapping poll failed: {error}");
+                }
+            }
+        });
+        sender
+    });
+    let _ = sender.send(instance);
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -259,5 +278,7 @@ pub extern "C" fn canvas_native_webgpu_buffer_map_async(
     let global = buffer.instance.global();
     let buffer_id = buffer.buffer;
 
-    let _ = global.buffer_map_async(buffer_id, offset, size, op);
+    if global.buffer_map_async(buffer_id, offset, size, op).is_ok() {
+        poll_mappings(Arc::clone(&buffer.instance));
+    }
 }

--- a/packages/canvas/platforms/ios/src/cpp/PromiseCallback.h
+++ b/packages/canvas/platforms/ios/src/cpp/PromiseCallback.h
@@ -36,7 +36,7 @@ struct PromiseCallback {
         CompleteCallback completeCallback_;
         CompleteCallback completeCallbackWrapper_;
         bool isPrepared_ = false;
-        void* data;
+        void* data = nullptr;
         mutable std::mutex mtx;
 
         Inner(v8::Isolate *isolate, v8::Local<v8::Promise::Resolver> callback,

--- a/tools/tests/webgpu-map-progress.spec.js
+++ b/tools/tests/webgpu-map-progress.spec.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { GPU, GPUBufferUsage, GPUMapMode } from '@nativescript/canvas';
+
+// Run inside a native runtime, with no WebGPU canvas or requestAnimationFrame.
+describe('WebGPU mapping progress', () => {
+  it('maps compute output, remaps, and rejects an invalid range', async () => {
+    const adapter = await new GPU().requestAdapter();
+    expect(adapter).toBeTruthy();
+    const device = await adapter.requestDevice();
+    const output = device.createBuffer({ size: 16, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const readback = device.createBuffer({ size: 16, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST });
+    const module = device.createShaderModule({ code: '@group(0) @binding(0) var<storage, read_write> values: array<u32>; @compute @workgroup_size(1) fn main() { values[0] = 42u; }' });
+    const pipeline = device.createComputePipeline({ layout: 'auto', compute: { module, entryPoint: 'main' } });
+    const bindGroup = device.createBindGroup({ layout: pipeline.getBindGroupLayout(0), entries: [{ binding: 0, resource: { buffer: output } }] });
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    encoder.copyBufferToBuffer(output, 0, readback, 0, 16);
+    device.queue.submit([encoder.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    expect(new Uint32Array(readback.getMappedRange())[0]).toBe(42);
+    readback.unmap();
+    // A second map also progresses without submitting or rendering another frame.
+    await readback.mapAsync(GPUMapMode.READ);
+    expect(new Uint32Array(readback.getMappedRange())[0]).toBe(42);
+    readback.unmap();
+    await expect(readback.mapAsync(GPUMapMode.READ, 1, 4)).rejects.toThrow();
+    readback.destroy();
+    output.destroy();
+    device.destroy();
+  });
+});


### PR DESCRIPTION
Compute-only WebGPU workloads can wait forever in GPUBuffer.mapAsync() because wgpu mapping callbacks require polling. Service polling on one background worker and initialize the Apple promise callback payload.

## Validation

The native regression submits compute work, reads back 42, remaps without another submission or frame, and rejects an invalid range. Both tvOS native slices rebuilt and the exact committed spec passed in the source-built simulator runtime. No WebGPU canvas or render loop is created. Android/device execution was not rerun; the fix is independent of tvOS.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `1bd9e03474e53ecf45d3f38e05db3847f7439b48`, changing 3 files against `1fd6ef470dfdfd43b3385fa7ef43feddd1debd06`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
