### PR TITLE
fix(canvas): avoid double-free when ImageData pixel buffers are collected

### DIFF
--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/ImageDataImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/ImageDataImpl.cpp
@@ -8,8 +8,9 @@
 
 struct ImageDataBuffer {
 public:
-    explicit ImageDataBuffer(ImageData *imageData) : imageData_(imageData) {
-        this->slice_ = canvas_native_image_data_get_data(imageData_);
+    explicit ImageDataBuffer(ImageData *imageData) {
+        // The buffer owns a clone of the pixel storage; ImageDataImpl owns imageData.
+        this->slice_ = canvas_native_image_data_get_data(imageData);
         this->buf_ = canvas_native_u8_buffer_get_bytes_mut(slice_);
         this->size_ = canvas_native_u8_buffer_get_length(slice_);
     }
@@ -25,14 +26,11 @@ public:
     ~ImageDataBuffer() {
         canvas_native_u8_buffer_release(slice_);
         slice_ = nullptr;
-        canvas_native_image_data_release(imageData_);
-        imageData_ = nullptr;
     }
 
 private:
     uint8_t *buf_;
     size_t size_;
-    ImageData *imageData_;
     U8Buffer *slice_;
 };
 

--- a/tools/tests/imagedata-ownership.js
+++ b/tools/tests/imagedata-ownership.js
@@ -1,0 +1,26 @@
+// Run in a NativeScript Apple runtime. Rejects if explicit GC is unavailable.
+// Pixel views must survive collection of their ImageData wrapper, and collecting
+// both must release each native allocation only once (including V8 worker GC).
+export async function checkImageDataOwnership(ImageData) {
+  if (typeof global.gc !== 'function') throw new Error('NativeScript global.gc is required');
+  for (let round = 0; round < 8; round++) {
+    const retained = [];
+    for (let i = 0; i < 512; i++) {
+      const image = new ImageData(4, 4);
+      const bytes = image.data;
+      bytes.set([i % 256, round, 127, 255]);
+      if (i % 64 === 0) retained.push({ bytes, expected: i % 256 });
+    }
+    global.gc();
+    await new Promise(resolve => setTimeout(resolve, 25));
+    for (const { bytes, expected } of retained) {
+      if (bytes[0] !== expected || bytes[1] !== round || bytes[2] !== 127 || bytes[3] !== 255)
+        throw new Error('ImageData view changed after wrapper collection');
+      bytes[0] = 255;
+      if (bytes[0] !== 255) throw new Error('Retained ImageData view is not writable');
+    }
+  }
+  global.gc();
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return { allocations: 4096, retainedViews: 64 };
+}


### PR DESCRIPTION
Accessing `ImageData.data` creates an ArrayBuffer whose deleter released both its owned U8Buffer and the borrowed ImageData pointer. ImageDataImpl also releases that pointer. On a physical Apple TV with NativeScript 9.1 / V8 14.9, Canvas pixel readback followed by garbage collection crashed in `canvas_native_image_data_release` on a V8 worker thread.

Release only the U8Buffer in the ArrayBuffer deleter. The Rust buffer already owns a clone of the pixel storage, so a retained Uint8ClampedArray remains valid after its ImageData wrapper is collected. This is an existing Apple bridge ownership bug, independent of tvOS platform support.

Validation: the signed physical-device Release game now passes seven pixel/state checks and the included `tools/tests/imagedata-ownership.js` regression. The regression creates 4,096 images, forces GC, and checks 64 retained pixel views for stable contents and writable storage. Call `await checkImageDataOwnership(ImageData)` inside a NativeScript Apple runtime with `global.gc` available. The public tvOS reviewer fixture also runs it. The original device crash and fresh passing results are retained in the private recovery evidence. iOS hardware has not been rerun for this fix.
