### PR TITLE
fix(canvas2d): return TextMetrics for empty measureText

### DIFF
--- a/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.cpp
+++ b/packages/canvas/platforms/ios/src/cpp/canvas2d/CanvasRenderingContext2DImpl.cpp
@@ -3133,7 +3133,8 @@ CanvasRenderingContext2DImpl::MeasureText(const v8::FunctionCallbackInfo<v8::Val
     }
 
     const int text_utf8_len = canvas::Utf8Length(js_str, isolate);
-    if (text_utf8_len == 0) return;
+    // Empty strings still return a TextMetrics instance, as required by Canvas 2D.
+    // Pixi 8 CanvasTextSystem reads .width on empty remainder strings.
 
     auto &scratch = g_tls_scratch;
     const size_t prefix_len = ptr->cached_font_.size() + 1


### PR DESCRIPTION
## Problem

Pixi 8 `CanvasTextSystem._drawLetterSpacing` always calls `context.measureText(remainder).width`. When the remainder is `""`, NativeScript Canvas returned without constructing a `TextMetrics` object, so `.width` threw and any `new Text(...)` crashed on iOS/tvOS.

## Change

Remove the `if (text_utf8_len == 0) return;` guard. Empty strings go through the existing text engine/cache and return a metrics instance with width 0, matching browsers.

## Test plan

- `measureText("")` is an object with `width === 0`
- Pixi `Text` with default letter-spacing no longer throws on NativeScript Canvas
- Verified on Apple TV simulator with Pixi 8.5.2 (NEONLEAP)

Does not include the concentric-radial Skia experiment; two-point conical already fades correctly on this stack.